### PR TITLE
security: sanitize Phase 3 titles and Phase 4a non-infeasible branch

### DIFF
--- a/internal/comment/builder.go
+++ b/internal/comment/builder.go
@@ -71,7 +71,7 @@ func Build(r TriageResult) string {
 		if len(openDups) > 0 {
 			parts = append(parts, "*Potentially related open issues:*")
 			for _, d := range openDups {
-				parts = append(parts, fmt.Sprintf("- #%d \u2014 \"%s\" (%d%% similar) \u2014 %s", d.Number, d.Title, d.Similarity, sanitizeLLMOutput(d.Reason)))
+				parts = append(parts, fmt.Sprintf("- #%d \u2014 \"%s\" (%d%% similar) \u2014 %s", d.Number, sanitizeLLMOutput(d.Title), d.Similarity, sanitizeLLMOutput(d.Reason)))
 			}
 			parts = append(parts, "")
 		}
@@ -83,7 +83,7 @@ func Build(r TriageResult) string {
 				if d.Milestone != nil {
 					resolvedNote = fmt.Sprintf("Resolved in %s", *d.Milestone)
 				}
-				parts = append(parts, fmt.Sprintf("- #%d \u2014 \"%s\" (%s) \u2014 %s", d.Number, d.Title, resolvedNote, sanitizeLLMOutput(d.Reason)))
+				parts = append(parts, fmt.Sprintf("- #%d \u2014 \"%s\" (%s) \u2014 %s", d.Number, sanitizeLLMOutput(d.Title), resolvedNote, sanitizeLLMOutput(d.Reason)))
 			}
 			parts = append(parts, "")
 		}
@@ -125,7 +125,7 @@ func Build(r TriageResult) string {
 					sanitizeLLMOutput(ctx.Topic), sanitizeURL(ctx.DocURL), sourceLabel, updatedNote, sanitizeLLMOutput(ctx.Reason)))
 			} else {
 				parts = append(parts, fmt.Sprintf("- [%s](%s) (%s, %s)%s \u2014 %s",
-					ctx.Topic, ctx.DocURL, sourceLabel, statusLabel, updatedNote, sanitizeLLMOutput(ctx.Reason)))
+					sanitizeLLMOutput(ctx.Topic), sanitizeURL(ctx.DocURL), sourceLabel, statusLabel, updatedNote, sanitizeLLMOutput(ctx.Reason)))
 			}
 		}
 		parts = append(parts, "")

--- a/internal/comment/builder_test.go
+++ b/internal/comment/builder_test.go
@@ -105,6 +105,45 @@ func TestBuild_BugWithDuplicates(t *testing.T) {
 	}
 }
 
+func TestBuild_Phase3SanitizesDuplicateTitles(t *testing.T) {
+	milestone := "v3.0"
+	result := TriageResult{
+		IsBug: true,
+		Phase3: []phases.Duplicate{
+			{Number: 200, Title: "[evil](javascript:alert(1))", State: "open", Reason: "looks similar", Similarity: 90},
+			{Number: 201, Title: "[pwned](data:text/html,<script>)", State: "closed", Reason: "same root cause", Similarity: 75, Milestone: &milestone},
+		},
+	}
+	got := Build(result)
+
+	if strings.Contains(got, "javascript:") {
+		t.Error("Phase 3 open duplicate title was not sanitized: javascript: scheme still present")
+	}
+	if strings.Contains(got, "data:text") {
+		t.Error("Phase 3 closed duplicate title was not sanitized: data: scheme still present")
+	}
+	if !strings.Contains(got, "[evil](removed)") {
+		t.Error("expected sanitized open duplicate title with (removed) link")
+	}
+	if !strings.Contains(got, "[pwned](removed)") {
+		t.Error("expected sanitized closed duplicate title with (removed) link")
+	}
+}
+
+func TestBuild_Phase4aSanitizesNonInfeasibleBranch(t *testing.T) {
+	result := TriageResult{
+		IsEnhancement: true,
+		Phase4a: []phases.ContextMatch{
+			{Topic: "[evil](javascript:alert(1))", Status: "planned", DocURL: "javascript:alert(1)", Source: "roadmap", Reason: "related"},
+		},
+	}
+	got := Build(result)
+
+	if strings.Contains(got, "javascript:") {
+		t.Error("Phase 4a non-infeasible branch was not sanitized: javascript: scheme still present")
+	}
+}
+
 func TestBuild_Enhancement(t *testing.T) {
 	lastUpdated := "2026-01-15"
 	result := TriageResult{


### PR DESCRIPTION
## Summary
- Wrap d.Title with sanitizeLLMOutput() in Phase 3 open and resolved duplicates
- Apply sanitizeLLMOutput/sanitizeURL to Phase 4a non-infeasible branch for consistency
- Add tests for markdown injection in duplicate titles and feature context

🤖 Generated with [Claude Code](https://claude.com/claude-code)