### PR TITLE
fix: compiled regexes, balanced JSON extraction, UTF-8 safe truncate

### DIFF
--- a/internal/phases/phase1.go
+++ b/internal/phases/phase1.go
@@ -5,6 +5,27 @@ import (
 	"strings"
 )
 
+// Pre-compiled regexes for known issue template section headers.
+var (
+	sectionReproSteps    = regexp.MustCompile(`### Reproduction steps\s*\n([\s\S]*?)(?:\n### |$)`)
+	sectionExpected      = regexp.MustCompile(`### Expected Behavior\s*\n([\s\S]*?)(?:\n### |$)`)
+	sectionDebug         = regexp.MustCompile(`### Debug\s*\n([\s\S]*?)(?:\n### |$)`)
+	sectionCanReproduce  = regexp.MustCompile(`### Can you reproduce this bug on the Microsoft Teams web app \(https://teams\.microsoft\.com\)\?\s*\n([\s\S]*?)(?:\n### |$)`)
+	reNumberedMarkers    = regexp.MustCompile(`(?m)^\s*\d+\.\s*`)
+	reDebugBash          = regexp.MustCompile(`(?m)^bash\s*$`)
+	reDebugMarkdown      = regexp.MustCompile(`(?m)^markdown\s*$`)
+	reDebugElectron      = regexp.MustCompile(`ELECTRON_ENABLE_LOGGING=true\s+teams-for-linux\s+--logConfig='[^']*'`)
+	reStripFences        = regexp.MustCompile("`{3,}[\\w]*\n?")
+)
+
+// sectionRegexes maps header names to their pre-compiled regex for getSection fallback.
+var sectionRegexes = map[string]*regexp.Regexp{
+	"Reproduction steps": sectionReproSteps,
+	"Expected Behavior":  sectionExpected,
+	"Debug":              sectionDebug,
+	"Can you reproduce this bug on the Microsoft Teams web app (https://teams.microsoft.com)?": sectionCanReproduce,
+}
+
 // Phase1 analyzes a bug report body for missing information and PWA reproducibility.
 // This is pure string parsing with no external dependencies.
 func Phase1(body string) Phase1Result {
@@ -48,6 +69,14 @@ func Phase1(body string) Phase1Result {
 
 // getSection extracts the content under a ### header in a GitHub issue form body.
 func getSection(body, header string) string {
+	if re, ok := sectionRegexes[header]; ok {
+		match := re.FindStringSubmatch(body)
+		if len(match) < 2 {
+			return ""
+		}
+		return strings.TrimSpace(match[1])
+	}
+	// Fallback for unknown headers: compile on the fly.
 	escaped := regexp.QuoteMeta(header)
 	re := regexp.MustCompile(`### ` + escaped + `\s*\n([\s\S]*?)(?:\n### |$)`)
 	match := re.FindStringSubmatch(body)
@@ -67,7 +96,7 @@ func isDefaultStepsTemplate(content string) bool {
 		return true
 	}
 	// Remove numbered list markers and ellipsis, then check if anything remains
-	withoutMarkers := regexp.MustCompile(`(?m)^\s*\d+\.\s*`).ReplaceAllString(cleaned, "")
+	withoutMarkers := reNumberedMarkers.ReplaceAllString(cleaned, "")
 	withoutMarkers = strings.NewReplacer("...", "").Replace(withoutMarkers)
 	withoutMarkers = strings.TrimSpace(withoutMarkers)
 	return withoutMarkers == ""
@@ -84,17 +113,14 @@ func isDebugMissing(content string) bool {
 	}
 	// Remove known defaults from the template
 	withoutDefaults := cleaned
-	withoutDefaults = regexp.MustCompile(`(?m)^bash\s*$`).ReplaceAllString(withoutDefaults, "")
-	withoutDefaults = regexp.MustCompile(`(?m)^markdown\s*$`).ReplaceAllString(withoutDefaults, "")
-	withoutDefaults = regexp.MustCompile(
-		`ELECTRON_ENABLE_LOGGING=true\s+teams-for-linux\s+--logConfig='[^']*'`,
-	).ReplaceAllString(withoutDefaults, "")
+	withoutDefaults = reDebugBash.ReplaceAllString(withoutDefaults, "")
+	withoutDefaults = reDebugMarkdown.ReplaceAllString(withoutDefaults, "")
+	withoutDefaults = reDebugElectron.ReplaceAllString(withoutDefaults, "")
 	withoutDefaults = strings.TrimSpace(withoutDefaults)
 	return withoutDefaults == ""
 }
 
 // stripFences removes markdown code fence markers.
 func stripFences(text string) string {
-	re := regexp.MustCompile("`{3,}[\\w]*\n?")
-	return strings.TrimSpace(re.ReplaceAllString(text, ""))
+	return strings.TrimSpace(reStripFences.ReplaceAllString(text, ""))
 }

--- a/internal/phases/phase2.go
+++ b/internal/phases/phase2.go
@@ -6,10 +6,14 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/IsmaelMartinez/github-issue-triage-bot/internal/llm"
 	"github.com/IsmaelMartinez/github-issue-triage-bot/internal/store"
 )
+
+// Pre-compiled regex for stripping code fences across phases.
+var reStripCodeFences = regexp.MustCompile("(?s)```[\\s\\S]*?```")
 
 // Phase2 searches for matching troubleshooting documentation using vector similarity
 // and then asks the LLM to pick the best matches with actionable suggestions.
@@ -89,35 +93,72 @@ Respond with ONLY valid JSON, no other text.`
 // Helper functions shared across phases
 
 func stripCodeFences(text string, maxLen int) string {
-	re := regexp.MustCompile("(?s)```[\\s\\S]*?```")
-	result := re.ReplaceAllString(text, "")
-	if len(result) > maxLen {
-		result = result[:maxLen]
-	}
-	return result
+	result := reStripCodeFences.ReplaceAllString(text, "")
+	return truncate(result, maxLen)
 }
 
+// truncate shortens s to at most maxLen bytes, backing up to a valid UTF-8
+// rune boundary so multi-byte sequences are never split.
 func truncate(s string, maxLen int) string {
-	if len(s) > maxLen {
-		return s[:maxLen]
+	if len(s) <= maxLen {
+		return s
 	}
-	return s
+	// Walk back from maxLen until we land on the start of a UTF-8 rune.
+	for maxLen > 0 && !utf8.RuneStart(s[maxLen]) {
+		maxLen--
+	}
+	return s[:maxLen]
 }
 
+// extractJSONArray finds the first top-level JSON array in raw by matching
+// balanced brackets, avoiding the greedy-regex problem of matching the first
+// '[' to the last ']'.
 func extractJSONArray(raw string) string {
-	re := regexp.MustCompile(`\[[\s\S]*\]`)
-	match := re.FindString(raw)
-	if match != "" {
-		return match
-	}
-	return "[]"
+	return extractBalanced(raw, '[', ']', "[]")
 }
 
+// extractJSONObject finds the first top-level JSON object in raw by matching
+// balanced braces.
 func extractJSONObject(raw string) string {
-	re := regexp.MustCompile(`\{[\s\S]*\}`)
-	match := re.FindString(raw)
-	if match != "" {
-		return match
+	return extractBalanced(raw, '{', '}', "{}")
+}
+
+// extractBalanced finds the first occurrence of open in raw, then walks forward
+// counting balanced open/close characters (skipping string literals) to find
+// the matching close. Returns fallback if no balanced match is found.
+func extractBalanced(raw string, open, close byte, fallback string) string {
+	start := strings.IndexByte(raw, open)
+	if start < 0 {
+		return fallback
 	}
-	return "{}"
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(raw); i++ {
+		ch := raw[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' && inString {
+			escaped = true
+			continue
+		}
+		if ch == '"' {
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		if ch == open {
+			depth++
+		} else if ch == close {
+			depth--
+			if depth == 0 {
+				return raw[start : i+1]
+			}
+		}
+	}
+	return fallback
 }


### PR DESCRIPTION
## Summary
- Move Phase 1 regexes to package-level compiled vars (avoid per-call MustCompile)
- Replace greedy extractJSONArray/extractJSONObject with balanced-bracket extraction
- Fix truncate() to respect UTF-8 rune boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)