### PR TITLE
fix: harden /report endpoint, set IVFFlat probes, add delivery TTL

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -67,6 +67,13 @@ func main() {
 	}
 	logger.Info("connected to database")
 
+	// Clean up old webhook delivery records (30-day retention)
+	if deleted, err := s.CleanupOldDeliveries(ctx, 30*24*time.Hour); err != nil {
+		logger.Error("cleanup old deliveries failed", "error", err)
+	} else if deleted > 0 {
+		logger.Info("cleaned up old deliveries", "deleted", deleted)
+	}
+
 	// Initialize clients
 	llmClient := llm.New(geminiAPIKey)
 	ghClient := gh.New(appID, privateKey)
@@ -84,10 +91,18 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, "ok")
 	})
+	allowedRepos := map[string]bool{"IsmaelMartinez/teams-for-linux": true}
+	if sourceRepo != "" {
+		allowedRepos[sourceRepo] = true
+	}
 	mux.HandleFunc("/report", func(w http.ResponseWriter, r *http.Request) {
 		repo := r.URL.Query().Get("repo")
 		if repo == "" {
 			repo = "IsmaelMartinez/teams-for-linux"
+		}
+		if !allowedRepos[repo] {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
 		}
 		stats, err := s.GetDashboardStats(r.Context(), repo)
 		if err != nil {
@@ -95,7 +110,6 @@ func main() {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("Access-Control-Allow-Origin", "*")
 		json.NewEncoder(w).Encode(stats)
 	})
 

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -69,7 +70,17 @@ func (s *Store) UpsertIssue(ctx context.Context, issue Issue) error {
 
 // FindSimilarDocuments returns the top-k documents closest to the given embedding, filtered by repo and doc types.
 func (s *Store) FindSimilarDocuments(ctx context.Context, repo string, docTypes []string, embedding []float32, limit int) ([]SimilarDocument, error) {
-	rows, err := s.pool.Query(ctx, `
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx, "SET LOCAL ivfflat.probes = 5"); err != nil {
+		return nil, fmt.Errorf("set ivfflat.probes: %w", err)
+	}
+
+	rows, err := tx.Query(ctx, `
 		SELECT id, repo, doc_type, title, content, metadata, embedding,
 		       created_at, updated_at,
 		       embedding <=> $1 AS distance
@@ -100,12 +111,25 @@ func (s *Store) FindSimilarDocuments(ctx context.Context, repo string, docTypes 
 		sd.Embedding = vec.Slice()
 		results = append(results, sd)
 	}
-	return results, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return results, tx.Commit(ctx)
 }
 
 // FindSimilarIssues returns the top-k issues closest to the given embedding, excluding the specified issue number.
 func (s *Store) FindSimilarIssues(ctx context.Context, repo string, embedding []float32, excludeNumber int, limit int) ([]SimilarIssue, error) {
-	rows, err := s.pool.Query(ctx, `
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx, "SET LOCAL ivfflat.probes = 6"); err != nil {
+		return nil, fmt.Errorf("set ivfflat.probes: %w", err)
+	}
+
+	rows, err := tx.Query(ctx, `
 		SELECT id, repo, number, title, summary, state, labels, milestone,
 		       embedding, created_at, updated_at, closed_at,
 		       embedding <=> $1 AS distance
@@ -134,7 +158,10 @@ func (s *Store) FindSimilarIssues(ctx context.Context, repo string, embedding []
 		si.Embedding = vec.Slice()
 		results = append(results, si)
 	}
-	return results, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return results, tx.Commit(ctx)
 }
 
 // HasBotCommented checks if the bot has already commented on the given issue.
@@ -176,6 +203,17 @@ func (s *Store) CheckAndRecordDelivery(ctx context.Context, deliveryID string) (
 		SELECT NOT EXISTS(SELECT 1 FROM ins)
 	`, deliveryID).Scan(&exists)
 	return exists, err
+}
+
+// CleanupOldDeliveries deletes webhook delivery records older than the given duration.
+// Returns the number of rows deleted.
+func (s *Store) CleanupOldDeliveries(ctx context.Context, olderThan time.Duration) (int64, error) {
+	cutoff := time.Now().Add(-olderThan)
+	tag, err := s.pool.Exec(ctx, `DELETE FROM webhook_deliveries WHERE created_at < $1`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
 }
 
 // ConnectPool creates a new pgxpool connection pool from a database URL.


### PR DESCRIPTION
## Summary
- Remove wildcard CORS from /report, add repo allowlist validation
- Set IVFFlat probes=sqrt(lists) via SET LOCAL in vector queries
- Add CleanupOldDeliveries with 30-day retention, called at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)