### PR TITLE
security: migrate GITHUB_APP_ID to Secret Manager

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -74,6 +74,7 @@ variable "gemini_api_key" {
 variable "github_app_id" {
   description = "GitHub App ID for authentication"
   type        = string
+  sensitive   = true
 }
 
 variable "github_private_key" {
@@ -182,6 +183,27 @@ resource "google_secret_manager_secret_iam_member" "gemini_api_key" {
   member    = "serviceAccount:${google_service_account.triage_bot.email}"
 }
 
+resource "google_secret_manager_secret" "github_app_id" {
+  secret_id = "triage-bot-github_app_id"
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.secretmanager]
+}
+
+resource "google_secret_manager_secret_version" "github_app_id" {
+  secret      = google_secret_manager_secret.github_app_id.id
+  secret_data = var.github_app_id
+}
+
+resource "google_secret_manager_secret_iam_member" "github_app_id" {
+  secret_id = google_secret_manager_secret.github_app_id.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.triage_bot.email}"
+}
+
 resource "google_secret_manager_secret" "github_private_key" {
   secret_id = "triage-bot-github_private_key"
 
@@ -258,8 +280,13 @@ resource "google_cloud_run_v2_service" "triage_bot" {
         }
       }
       env {
-        name  = "GITHUB_APP_ID"
-        value = var.github_app_id
+        name = "GITHUB_APP_ID"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.github_app_id.secret_id
+            version = "latest"
+          }
+        }
       }
       env {
         name = "GITHUB_PRIVATE_KEY"


### PR DESCRIPTION
## Summary
- Add Secret Manager resources for github_app_id (secret, version, IAM)
- Change Cloud Run env from plaintext value to secret_key_ref
- Consistent with all other secrets in the service

🤖 Generated with [Claude Code](https://claude.com/claude-code)