### PR TITLE
fix: centralize enhancement doc types and validate at seed time

### DIFF
--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -194,6 +194,18 @@ func seedFeatures(ctx context.Context, s *store.Store, l *llm.Client, repo strin
 	}
 
 	for i, e := range entries {
+		// Validate doc_type against allowed enhancement types
+		validType := false
+		for _, dt := range store.EnhancementDocTypes {
+			if e.Source == dt {
+				validType = true
+				break
+			}
+		}
+		if !validType {
+			return fmt.Errorf("feature %d has invalid source %q, must be one of %v", i, e.Source, store.EnhancementDocTypes)
+		}
+
 		text := fmt.Sprintf("%s\n%s", e.Topic, e.Summary)
 		embedding, err := l.Embed(ctx, text)
 		if err != nil {

--- a/internal/phases/phase4a.go
+++ b/internal/phases/phase4a.go
@@ -23,7 +23,7 @@ func Phase4a(ctx context.Context, s *store.Store, l *llm.Client, repo, title, bo
 	}
 
 	// Find similar features/ADRs/research
-	docs, err := s.FindSimilarDocuments(ctx, repo, []string{"roadmap", "adr", "research"}, embedding, 5)
+	docs, err := s.FindSimilarDocuments(ctx, repo, store.EnhancementDocTypes, embedding, 5)
 	if err != nil {
 		return nil, fmt.Errorf("find similar features: %w", err)
 	}

--- a/internal/store/models.go
+++ b/internal/store/models.go
@@ -54,3 +54,7 @@ type SimilarIssue struct {
 	Issue
 	Distance float64
 }
+
+// EnhancementDocTypes lists the document types that Phase 4a searches for
+// enhancement context. The seed command validates against this list.
+var EnhancementDocTypes = []string{"roadmap", "adr", "research"}


### PR DESCRIPTION
## Summary
- Extracts the hardcoded `["roadmap", "adr", "research"]` doc type list from Phase 4a into `store.EnhancementDocTypes` so the allowed types are defined in one place.
- Updates Phase 4a to reference the new constant instead of its own inline slice.
- Adds validation in `cmd/seed/main.go` `seedFeatures` to reject entries with a `source` value not in the allowed list, catching bad seed data early.

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)