### PR TITLE
fix: flag missing info for free-form issues without template headers

### DIFF
--- a/internal/phases/phase1.go
+++ b/internal/phases/phase1.go
@@ -31,8 +31,19 @@ var sectionRegexes = map[string]*regexp.Regexp{
 func Phase1(body string) Phase1Result {
 	var result Phase1Result
 
-	// If the body has no form sections at all, there's nothing to analyze
+	// Empty or whitespace-only bodies have nothing to analyze.
+	if strings.TrimSpace(body) == "" {
+		return result
+	}
+
+	// If the body has content but no form sections, all template fields are missing.
 	if !strings.Contains(body, "### ") {
+		result.MissingItems = []MissingItem{
+			{Label: "Reproduction steps", Detail: "Step-by-step instructions to trigger the bug (the more specific, the faster we can investigate)"},
+			{Label: "Debug console output", Detail: "Log output from running the application with debug logging enabled"},
+			{Label: "Expected behavior", Detail: "A description of what you expected to happen instead"},
+			{Label: "PWA reproducibility", Detail: "Whether the issue also occurs on the Microsoft Teams web app"},
+		}
 		return result
 	}
 

--- a/internal/phases/phase1_test.go
+++ b/internal/phases/phase1_test.go
@@ -118,6 +118,18 @@ func TestPhase1(t *testing.T) {
 			wantPWA:          false,
 		},
 		{
+			name:             "free-form text without template headers",
+			body:             "The app crashes when I try to open it. It just shows a white screen and nothing happens.",
+			wantMissingCount: 4,
+			wantPWA:          false,
+		},
+		{
+			name:             "single line issue without headers",
+			body:             "Screen sharing broken on Wayland",
+			wantMissingCount: 4,
+			wantPWA:          false,
+		},
+		{
 			name: "partial info",
 			body: "### Can you reproduce this bug on the Microsoft Teams web app (https://teams.microsoft.com)?\n\nNo\n\n### Describe the bug\n\nCan't login\n\n### Reproduction steps\n\n1. Open app\n2. Enter credentials\n3. Click submit\n\n### Expected Behavior\n\n_No response_\n\n### Debug\n\n_No response_",
 			wantMissingCount: 2,


### PR DESCRIPTION
## Summary
- Phase 1 now returns all 4 missing-info items when an issue body contains text but no template headers (e.g. free-form bug reports), instead of silently returning nothing.
- Empty/whitespace-only bodies still return 0 missing items (unchanged behavior).

## Test plan
- [x] Two new test cases added: "free-form text without template headers" and "single line issue without headers", both expecting 4 missing items
- [x] Existing tests pass unchanged (`go test ./...` and `go vet ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)