### PR TITLE
ci: add shadow_repos config for agent sessions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,7 @@ jobs:
           TF_VAR_webhook_secret: ${{ secrets.TF_VAR_WEBHOOK_SECRET }}
           TF_VAR_billing_account_id: ${{ secrets.TF_VAR_BILLING_ACCOUNT_ID }}
           TF_VAR_source_repo: "IsmaelMartinez/teams-for-linux"
+          TF_VAR_shadow_repos: "IsmaelMartinez/teams-for-linux:IsmaelMartinez/teams-for-linux-shadow"
           TF_VAR_image_tag: sha-${{ github.sha }}
         run: |
           cd terraform


### PR DESCRIPTION
## Summary

- Add TF_VAR_shadow_repos to deploy workflow so Cloud Run gets the shadow repo mapping
- Maps IsmaelMartinez/teams-for-linux to IsmaelMartinez/teams-for-linux-shadow

## Test plan

- [x] Shadow repo created (private): IsmaelMartinez/teams-for-linux-shadow
- [ ] Deploy pipeline passes with new config
- [ ] Verify SHADOW_REPOS env var is set on Cloud Run service

🤖 Generated with [Claude Code](https://claude.com/claude-code)