### PR TITLE
fix: skip Phase 1 for enhancements, match approve keyword

### DIFF
--- a/internal/agent/orchestrator.go
+++ b/internal/agent/orchestrator.go
@@ -27,7 +27,7 @@ func ParseApprovalSignal(comment string) ApprovalSignal {
 	if strings.Contains(normalized, "reject") || strings.Contains(normalized, "close this") || strings.Contains(normalized, "cancel") {
 		return SignalReject
 	}
-	if strings.Contains(normalized, "lgtm") || strings.Contains(normalized, "approved") || strings.Contains(normalized, "👍") || strings.Contains(normalized, "looks good") {
+	if strings.Contains(normalized, "lgtm") || strings.Contains(normalized, "approve") || strings.Contains(normalized, "👍") || strings.Contains(normalized, "looks good") {
 		return SignalApproved
 	}
 	return SignalNone

--- a/internal/agent/orchestrator_test.go
+++ b/internal/agent/orchestrator_test.go
@@ -10,6 +10,7 @@ func TestParseApprovalSignal(t *testing.T) {
 	}{
 		{"lgtm lowercase", "lgtm", SignalApproved},
 		{"lgtm uppercase", "LGTM", SignalApproved},
+		{"approve lowercase", "approve", SignalApproved},
 		{"approved lowercase", "approved", SignalApproved},
 		{"approved with punctuation", "Approved!", SignalApproved},
 		{"thumbs up emoji", "👍", SignalApproved},

--- a/internal/comment/builder.go
+++ b/internal/comment/builder.go
@@ -21,8 +21,8 @@ type TriageResult struct {
 // Build constructs the consolidated markdown comment from all phase results.
 // Returns empty string if there is nothing to report.
 func Build(r TriageResult) string {
-	hasContent := len(r.Phase1.MissingItems) > 0 ||
-		r.Phase1.IsPwaReproducible ||
+	hasContent := (r.IsBug && len(r.Phase1.MissingItems) > 0) ||
+		(r.IsBug && r.Phase1.IsPwaReproducible) ||
 		len(r.Phase2) > 0 ||
 		len(r.Phase3) > 0 ||
 		len(r.Phase4a) > 0 ||
@@ -134,8 +134,8 @@ func Build(r TriageResult) string {
 
 	// --- Common sections ---
 
-	// Missing information checklist (bugs only for now)
-	if len(r.Phase1.MissingItems) > 0 {
+	// Missing information checklist (bugs only — Phase 1 checks bug template fields)
+	if r.IsBug && len(r.Phase1.MissingItems) > 0 {
 		parts = append(parts, "To help us investigate, could you provide some additional details?\n")
 		parts = append(parts, "**Missing information:**")
 		for _, item := range r.Phase1.MissingItems {


### PR DESCRIPTION
## Summary

- Phase 1 missing info (reproduction steps, debug logs, etc.) now only shows for bugs, not enhancements
- Approval signal parser now matches "approve" in addition to "approved"

🤖 Generated with [Claude Code](https://claude.com/claude-code)