### PR TITLE
fix: start agent session even when triage comment is empty

### DIFF
--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -24,7 +24,10 @@ func main() {
 		outPath = os.Args[1]
 	}
 
-	repo := "IsmaelMartinez/teams-for-linux"
+	repo := os.Getenv("DASHBOARD_REPO")
+	if repo == "" {
+		repo = "IsmaelMartinez/teams-for-linux"
+	}
 
 	ctx := context.Background()
 

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -272,32 +272,27 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 	issueLog.Info("phase 4b complete", "result", p4b)
 	result.Phase4b = p4b
 
-	// Build comment
+	// Build and post triage comment (if there's content to report)
 	body := comment.Build(result)
-	if body == "" {
-		issueLog.Info("nothing to report")
-		return
+	if body != "" {
+		commentID, err := h.github.CreateComment(ctx, installationID, repo, issue.Number, body)
+		if err != nil {
+			issueLog.Error("posting comment", "error", err)
+		} else {
+			phasesRun := collectPhasesRun(result)
+			if err := h.store.RecordBotComment(ctx, store.BotComment{
+				Repo:        repo,
+				IssueNumber: issue.Number,
+				CommentID:   commentID,
+				PhasesRun:   phasesRun,
+			}); err != nil {
+				issueLog.Error("recording bot comment", "error", err)
+			}
+			issueLog.Info("comment posted", "phases", phasesRun)
+		}
+	} else {
+		issueLog.Info("nothing to report in triage comment")
 	}
-
-	// Post comment
-	commentID, err := h.github.CreateComment(ctx, installationID, repo, issue.Number, body)
-	if err != nil {
-		issueLog.Error("posting comment", "error", err)
-		return
-	}
-
-	// Record bot comment
-	phasesRun := collectPhasesRun(result)
-	if err := h.store.RecordBotComment(ctx, store.BotComment{
-		Repo:        repo,
-		IssueNumber: issue.Number,
-		CommentID:   commentID,
-		PhasesRun:   phasesRun,
-	}); err != nil {
-		issueLog.Error("recording bot comment", "error", err)
-	}
-
-	issueLog.Info("comment posted", "phases", phasesRun)
 
 	// Start agent session for enhancements with shadow repo
 	if isEnhancement {


### PR DESCRIPTION
## Summary
- Agent session for enhancements was not starting when the triage comment builder returned empty (no Phase 4a matches)
- The handler returned early at "nothing to report" and never reached the agent session start code
- Restructured flow so agent session starts regardless of triage comment content
- Also makes dashboard repo configurable via DASHBOARD_REPO env var

## Test plan
- [x] `go test ./...` passes
- [x] `go build ./...` compiles
- [ ] Deploy and verify enhancement issues create shadow issues even when no triage comment is posted