### PR TITLE
feat: treat replies on context briefs as feedback for research

### DIFF
--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -381,8 +381,13 @@ func (h *AgentHandler) handleContextBriefResponse(ctx context.Context, installat
 		return nil
 
 	default:
-		log.Info("ignoring non-signal comment on context brief")
-		return nil
+		// Treat any other comment as additional context/corrections and
+		// start the research pipeline with the feedback incorporated.
+		log.Info("feedback on context brief, starting research with additional context")
+		title, _ := sess.Context["title"].(string)
+		body, _ := sess.Context["body"].(string)
+		feedback := []string{commentBody}
+		return h.startResearch(ctx, installationID, sess.ID, sess.ShadowRepo, sess.ShadowIssueNumber, sess.Repo, sess.IssueNumber, title, body, feedback)
 	}
 }
 

--- a/internal/agent/research.go
+++ b/internal/agent/research.go
@@ -253,7 +253,7 @@ func FormatContextBriefMarkdown(brief *ContextBrief) string {
 		sb.WriteString("\n")
 	}
 
-	sb.WriteString("Reply `research` to trigger full Gemini research synthesis, `use as context` to acknowledge, or `reject` to close.")
+	sb.WriteString("Reply `research` to trigger full Gemini research synthesis, `use as context` to acknowledge, `reject` to close, or reply with corrections/additional context to refine the analysis.")
 
 	return sb.String()
 }


### PR DESCRIPTION
## Summary

Non-signal comments on context briefs now start the research pipeline with the comment as additional context, instead of being silently ignored. This lets maintainers reply with corrections or extra context to refine the analysis. Updated the brief footer to explain this option.

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)