### PR TITLE
docs: add simili-bot evaluation and external tool delegation to roadmap

### DIFF
--- a/docs/plans/2026-03-04-roadmap.md
+++ b/docs/plans/2026-03-04-roadmap.md
@@ -318,9 +318,9 @@ Implemented in PR #103 (2026-04-01). Task 19: synthesis stats added to the `/das
 
 Concrete next steps (updated 2026-04-02):
 
-1. ~~Steps 1-36: all completed.~~ See git history for details.
-37. Publish v0.1.0 release via GitHub Releases.
-38. Write first agent when a real need emerges (e.g. triage reviewer digest, ADR revision proposals). Start with the simplest one, validate the execution model (Claude CLI headless in Actions, MCP connections), iterate.
+1. ~~Steps 1-37: all completed.~~ v0.1.0 released 2026-04-01. See git history for details.
+38. Evaluate [simili-bot](https://github.com/similigh/simili-bot) for duplicate detection. It uses Gemini embeddings + Qdrant for semantic similarity and runs as a GitHub Action in `similarity-only` mode. This fills the gap left by removing Phase 3 (duplicate detection) without adding complexity to the triage bot. Trial it on teams-for-linux alongside the existing triage pipeline.
+39. Write first agent when a real need emerges (e.g. triage reviewer digest, ADR revision proposals). Start with the simplest one, validate the execution model.
 
 Open issues for future consideration:
 - #50: Mirror public repo codebase into shadow repos (enables code-aware research for agents)
@@ -328,10 +328,11 @@ Open issues for future consideration:
 - ~~Integration with GitHub Agentic Workflows~~ No longer planned as a stream
 - ~~Deepen repo-butler integration~~ Both MCP servers shipped, integration is live
 - Q4 (retrospective compliance audit) — when 50+ sessions accumulate, write an agent.
+- Evaluate `actions/ai-inference` + GitHub AI labeler as a zero-infrastructure alternative for issue labelling.
 
 ## What We're Not Doing
 
-Generic triage features — labeling, deduplication, routing — are explicitly out of scope. The competitive analysis (2026-03-16) confirmed these are commodity features. GitHub Agentic Workflows will further commoditise operational chores (doc sync, test coverage, CI triage). New feature work should be evaluated against this framing: if a proposed feature could be offered by any generic or stateless agent, it's likely not worth building here. The differentiator is institutional memory and strategic reasoning over time.
+Generic triage features — labeling, deduplication, routing — are explicitly out of scope and should be handled by dedicated external tools. Duplicate detection was removed in Phase 3 (2026-03-15) and should be filled by simili-bot or a similar embedding-based tool running as a GitHub Action alongside this bot. Issue labelling can be handled by `actions/ai-inference` with GitHub Models. The competitive analysis (2026-03-16) confirmed these are commodity features. GitHub Agentic Workflows will further commoditise operational chores (doc sync, test coverage, CI triage). New feature work should be evaluated against this framing: if a proposed feature could be offered by any generic or stateless agent or existing tool, it's not worth building here. The differentiator is institutional memory and strategic reasoning over time.
 
 Roadmap proposals and portfolio-level reporting are delegated to repo-butler (2026-03-23). This bot provides the intelligence layer (synthesis findings, cluster detection, drift signals) via API endpoints; repo-butler consumes them and handles presentation, roadmap PRs, and improvement proposals. Do not duplicate planning or reporting features that repo-butler already provides.
 


### PR DESCRIPTION
## Summary

- Add simili-bot evaluation as concrete next step for filling the duplicate detection gap
- Note actions/ai-inference + GitHub AI labeler as future evaluation for issue labelling
- Update "What We're Not Doing" to explicitly recommend external tools for commodity features
- Mark v0.1.0 release as done (already published 2026-04-01)

## Test plan

- [ ] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated roadmap to reflect v0.1.0 release completion
  * Added evaluation plans for duplicate detection and AI-assisted issue labelling tooling
  * Clarified which features will be handled by external tools
  * Deferred first agent integration to a later phase

<!-- end of auto-generated comment: release notes by coderabbit.ai -->