### PR TITLE
feat: unified synthesis step — coherent triage responses

### DIFF
--- a/cmd/backfill/main.go
+++ b/cmd/backfill/main.go
@@ -86,7 +86,7 @@ func main() {
 		result.Phase1 = phases.Phase1(iss.Body)
 
 		if isBug {
-			p2, err := phases.Phase2(ctx, s, llmClient, issLog, dataRepo, iss.Title, iss.Body, "")
+			p2, err := phases.Phase2(ctx, s, llmClient, issLog, dataRepo, iss.Title, iss.Body, "", nil)
 			if err != nil {
 				issLog.Error("phase 2 failed", "error", err)
 			}
@@ -94,7 +94,7 @@ func main() {
 		}
 
 		if isEnhancement {
-			p4a, err := phases.Phase4a(ctx, s, llmClient, issLog, dataRepo, iss.Title, iss.Body)
+			p4a, err := phases.Phase4a(ctx, s, llmClient, issLog, dataRepo, iss.Title, iss.Body, nil)
 			if err != nil {
 				issLog.Error("phase 4a failed", "error", err)
 			}

--- a/cmd/backfill/main.go
+++ b/cmd/backfill/main.go
@@ -85,13 +85,20 @@ func main() {
 
 		result.Phase1 = phases.Phase1(iss.Body)
 
-		p2, err := phases.Phase2(ctx, s, llmClient, issLog, dataRepo, iss.Title, iss.Body, "", nil)
+		queryText := fmt.Sprintf("%s\n%s", phases.Truncate(iss.Title, 200), phases.StripCodeFences(iss.Body, 1500))
+		preEmbedding, embedErr := llmClient.Embed(ctx, queryText)
+		if embedErr != nil {
+			issLog.Warn("shared embed failed, falling back to per-phase embedding", "error", embedErr)
+			preEmbedding = nil
+		}
+
+		p2, err := phases.Phase2(ctx, s, llmClient, issLog, dataRepo, iss.Title, iss.Body, "", preEmbedding)
 		if err != nil {
 			issLog.Error("phase 2 failed", "error", err)
 		}
 		result.Phase2 = p2
 
-		p4a, err := phases.Phase4a(ctx, s, llmClient, issLog, dataRepo, iss.Title, iss.Body, nil)
+		p4a, err := phases.Phase4a(ctx, s, llmClient, issLog, dataRepo, iss.Title, iss.Body, preEmbedding)
 		if err != nil {
 			issLog.Error("phase 4a failed", "error", err)
 		}

--- a/cmd/backfill/main.go
+++ b/cmd/backfill/main.go
@@ -85,21 +85,17 @@ func main() {
 
 		result.Phase1 = phases.Phase1(iss.Body)
 
-		if isBug {
-			p2, err := phases.Phase2(ctx, s, llmClient, issLog, dataRepo, iss.Title, iss.Body, "", nil)
-			if err != nil {
-				issLog.Error("phase 2 failed", "error", err)
-			}
-			result.Phase2 = p2
+		p2, err := phases.Phase2(ctx, s, llmClient, issLog, dataRepo, iss.Title, iss.Body, "", nil)
+		if err != nil {
+			issLog.Error("phase 2 failed", "error", err)
 		}
+		result.Phase2 = p2
 
-		if isEnhancement {
-			p4a, err := phases.Phase4a(ctx, s, llmClient, issLog, dataRepo, iss.Title, iss.Body, nil)
-			if err != nil {
-				issLog.Error("phase 4a failed", "error", err)
-			}
-			result.Phase4a = p4a
+		p4a, err := phases.Phase4a(ctx, s, llmClient, issLog, dataRepo, iss.Title, iss.Body, nil)
+		if err != nil {
+			issLog.Error("phase 4a failed", "error", err)
 		}
+		result.Phase4a = p4a
 
 		body := commentpkg.Build(result)
 		phasesRun := collectPhasesRun(result)

--- a/internal/comment/builder.go
+++ b/internal/comment/builder.go
@@ -24,7 +24,7 @@ type TriageResult struct {
 func Build(r TriageResult) string {
 	hasPwaNote := r.IsBug && !r.IsDocBug && r.Phase1.IsPwaReproducible
 	missingCount := countRelevantMissing(r)
-	hasContent := (r.IsBug && missingCount > 0) ||
+	hasContent := missingCount > 0 ||
 		hasPwaNote ||
 		len(r.Phase2) > 0 ||
 		len(r.Phase4a) > 0
@@ -47,8 +47,8 @@ func Build(r TriageResult) string {
 				"We'll still take a look.\n")
 	}
 
-	// Known issue matches from Phase 2 (bugs only)
-	if r.IsBug && len(r.Phase2) > 0 {
+	// Known issue matches from Phase 2
+	if len(r.Phase2) > 0 {
 		parts = append(parts, "**Possibly related:**\n")
 		for _, s := range r.Phase2 {
 			url := sanitizeURL(s.DocURL)
@@ -62,8 +62,8 @@ func Build(r TriageResult) string {
 		parts = append(parts, "")
 	}
 
-	// Enhancement context from Phase 4a (enhancements only)
-	if r.IsEnhancement && len(r.Phase4a) > 0 {
+	// Enhancement context from Phase 4a
+	if len(r.Phase4a) > 0 {
 		statusLabels := map[string]string{
 			"shipped":       "Shipped",
 			"planned":       "Planned",
@@ -136,15 +136,24 @@ func Build(r TriageResult) string {
 	}
 
 	// Footer: tip + feedback + bot disclosure
-	if r.IsBug {
-		parts = append(parts,
-			"*Bot suggestion \u2014 [Troubleshooting Guide](https://ismaelmartinez.github.io/teams-for-linux/troubleshooting) \u2014 "+
-				"react \U0001F44D/\U0001F44E or [share feedback](https://github.com/IsmaelMartinez/github-issue-triage-bot/issues/new?template=bot-feedback.yml).*")
-	} else {
-		parts = append(parts,
-			"*Bot suggestion \u2014 [Roadmap](https://ismaelmartinez.github.io/teams-for-linux/development/plan/roadmap) \u2014 "+
-				"react \U0001F44D/\U0001F44E or [share feedback](https://github.com/IsmaelMartinez/github-issue-triage-bot/issues/new?template=bot-feedback.yml).*")
+	// Link to relevant docs based on which phases produced output.
+	hasPhase2 := len(r.Phase2) > 0
+	hasPhase4a := len(r.Phase4a) > 0
+	var docLinks string
+	switch {
+	case hasPhase2 && hasPhase4a:
+		docLinks = "[Troubleshooting Guide](https://ismaelmartinez.github.io/teams-for-linux/troubleshooting) " +
+			"| [Roadmap](https://ismaelmartinez.github.io/teams-for-linux/development/plan/roadmap)"
+	case hasPhase2:
+		docLinks = "[Troubleshooting Guide](https://ismaelmartinez.github.io/teams-for-linux/troubleshooting)"
+	case hasPhase4a:
+		docLinks = "[Roadmap](https://ismaelmartinez.github.io/teams-for-linux/development/plan/roadmap)"
+	default:
+		docLinks = "[Project docs](https://ismaelmartinez.github.io/teams-for-linux)"
 	}
+	parts = append(parts,
+		"*Bot suggestion \u2014 "+docLinks+" \u2014 "+
+			"react \U0001F44D/\U0001F44E or [share feedback](https://github.com/IsmaelMartinez/github-issue-triage-bot/issues/new?template=bot-feedback.yml).*")
 
 	return strings.Join(parts, "\n")
 }

--- a/internal/comment/builder.go
+++ b/internal/comment/builder.go
@@ -158,6 +158,46 @@ func Build(r TriageResult) string {
 	return strings.Join(parts, "\n")
 }
 
+// Footer returns the bot disclosure footer line based on which phases produced output.
+func Footer(r TriageResult) string {
+	hasPhase2 := len(r.Phase2) > 0
+	hasPhase4a := len(r.Phase4a) > 0
+	var docLinks string
+	switch {
+	case hasPhase2 && hasPhase4a:
+		docLinks = "[Troubleshooting Guide](https://ismaelmartinez.github.io/teams-for-linux/troubleshooting) " +
+			"| [Roadmap](https://ismaelmartinez.github.io/teams-for-linux/development/plan/roadmap)"
+	case hasPhase2:
+		docLinks = "[Troubleshooting Guide](https://ismaelmartinez.github.io/teams-for-linux/troubleshooting)"
+	case hasPhase4a:
+		docLinks = "[Roadmap](https://ismaelmartinez.github.io/teams-for-linux/development/plan/roadmap)"
+	default:
+		docLinks = "[Project docs](https://ismaelmartinez.github.io/teams-for-linux)"
+	}
+	return "*Bot suggestion \u2014 " + docLinks + " \u2014 " +
+		"react \U0001F44D/\U0001F44E or [share feedback](https://github.com/IsmaelMartinez/github-issue-triage-bot/issues/new?template=bot-feedback.yml).*"
+}
+
+// DebugInstructions returns the collapsible debug log instructions block,
+// or empty string if debug logs are not missing.
+func DebugInstructions(r TriageResult) string {
+	if !r.IsBug || r.IsDocBug {
+		return ""
+	}
+	for _, item := range r.Phase1.MissingItems {
+		if item.Label == "Debug console output" {
+			return "<details>\n" +
+				"<summary>How to get debug logs</summary>\n\n" +
+				"```bash\n" +
+				"ELECTRON_ENABLE_LOGGING=true teams-for-linux --logConfig='{\"transports\":{\"console\":{\"level\":\"debug\"}}}'\n" +
+				"```\n" +
+				"Reproduce the issue and copy the relevant output.\n\n" +
+				"</details>\n"
+		}
+	}
+	return ""
+}
+
 // countRelevantMissing returns the number of missing items that will actually
 // be displayed, accounting for doc-bug filtering.
 func countRelevantMissing(r TriageResult) int {

--- a/internal/comment/builder.go
+++ b/internal/comment/builder.go
@@ -24,7 +24,8 @@ type TriageResult struct {
 func Build(r TriageResult) string {
 	hasPwaNote := r.IsBug && !r.IsDocBug && r.Phase1.IsPwaReproducible
 	missingCount := countRelevantMissing(r)
-	hasContent := missingCount > 0 ||
+	hasMissingInfo := r.IsBug && missingCount > 0
+	hasContent := hasMissingInfo ||
 		hasPwaNote ||
 		len(r.Phase2) > 0 ||
 		len(r.Phase4a) > 0

--- a/internal/comment/builder_test.go
+++ b/internal/comment/builder_test.go
@@ -39,8 +39,8 @@ func TestBuild_BugWithMissingInfo(t *testing.T) {
 	if !strings.Contains(got, "How to get debug logs") {
 		t.Error("missing debug instructions")
 	}
-	if !strings.Contains(got, "Troubleshooting Guide") {
-		t.Error("missing troubleshooting guide link")
+	if !strings.Contains(got, "Project docs") {
+		t.Error("missing project docs link in footer")
 	}
 	if !strings.Contains(got, "Bot suggestion") {
 		t.Error("missing bot disclosure")
@@ -219,5 +219,35 @@ func TestBuild_PreambleAppearsFirst(t *testing.T) {
 	preamble := "I checked this issue against the project's documentation and known issues."
 	if !strings.HasPrefix(got, preamble) {
 		t.Errorf("output should start with preamble, got: %q", got[:min(len(got), 100)])
+	}
+}
+
+func TestBuild_UnlabelledIssueWithPhase2(t *testing.T) {
+	result := TriageResult{
+		IsBug:         false,
+		IsEnhancement: false,
+		Phase2: []phases.Suggestion{
+			{Title: "Network Timeout", DocURL: "https://example.com/timeout", Reason: "similar network timeout reported"},
+		},
+	}
+	got := Build(result)
+
+	if got == "" {
+		t.Fatal("Build() should not return empty when Phase2 has suggestions for unlabelled issue")
+	}
+	if !strings.Contains(got, "checked this issue") {
+		t.Error("missing preamble")
+	}
+	if !strings.Contains(got, "Possibly related") {
+		t.Error("missing suggestions header")
+	}
+	if !strings.Contains(got, "[Network Timeout](https://example.com/timeout)") {
+		t.Error("missing suggestion link")
+	}
+	if !strings.Contains(got, "Troubleshooting Guide") {
+		t.Error("missing troubleshooting guide link in footer")
+	}
+	if !strings.Contains(got, "share feedback") {
+		t.Error("missing feedback link")
 	}
 }

--- a/internal/comment/sanitize.go
+++ b/internal/comment/sanitize.go
@@ -15,6 +15,11 @@ var (
 	dangerousSchemeRe = regexp.MustCompile(`(?i)^(javascript|data|vbscript):`)
 )
 
+// SanitizeLLMOutput strips images, dangerous links, script tags, and HTML from LLM text.
+func SanitizeLLMOutput(s string) string {
+	return sanitizeLLMOutput(s)
+}
+
 func sanitizeLLMOutput(s string) string {
 	s = gfmImageRe.ReplaceAllString(s, "")
 	s = gfmRefImageRe.ReplaceAllString(s, "")

--- a/internal/phases/phase2.go
+++ b/internal/phases/phase2.go
@@ -18,15 +18,21 @@ var reStripCodeFences = regexp.MustCompile("(?s)```[\\s\\S]*?```")
 
 // Phase2 searches for matching troubleshooting documentation using vector similarity
 // and then asks the LLM to pick the best matches with actionable suggestions.
-func Phase2(ctx context.Context, s store.PhaseQuerier, l llm.Provider, logger *slog.Logger, repo, title, body string, codeContext string) ([]Suggestion, error) {
+func Phase2(ctx context.Context, s store.PhaseQuerier, l llm.Provider, logger *slog.Logger, repo, title, body string, codeContext string, preEmbedding []float32) ([]Suggestion, error) {
 	logger.Info("phase2 start")
 	cleanBody := stripCodeFences(body, 1500)
 	queryText := fmt.Sprintf("%s\n%s", truncate(title, 200), cleanBody)
 
-	// Get embedding for the issue
-	embedding, err := l.Embed(ctx, queryText)
-	if err != nil {
-		return nil, fmt.Errorf("embed issue: %w", err)
+	// Use pre-computed embedding if provided, otherwise compute it
+	var embedding []float32
+	if len(preEmbedding) > 0 {
+		embedding = preEmbedding
+	} else {
+		var err error
+		embedding, err = l.Embed(ctx, queryText)
+		if err != nil {
+			return nil, fmt.Errorf("embed issue: %w", err)
+		}
 	}
 	// Find similar documents across all doc types (project + upstream)
 	docs, err := s.FindSimilarDocuments(ctx, repo, []string{"troubleshooting", "configuration", "adr", "roadmap", "research", "upstream_release", "upstream_issue"}, embedding, 5)
@@ -49,7 +55,7 @@ func Phase2(ctx context.Context, s store.PhaseQuerier, l llm.Provider, logger *s
 	}
 
 	systemPrompt := `You are a helpful assistant for the "Teams for Linux" open source project.
-Match this bug report against our documentation: troubleshooting guides, configuration options, architecture decisions (ADRs), roadmap items, and research documents.
+Match this issue against our documentation: troubleshooting guides, configuration options, architecture decisions (ADRs), roadmap items, and research documents.
 
 Return a JSON array of 0-3 matches. Only include sections with a strong connection (same symptoms, same error message, same component, or a documented decision/limitation that explains the behaviour). For each match, estimate a relevance percentage (60-95). Only include matches above 60%%.
 
@@ -62,7 +68,7 @@ Respond with ONLY valid JSON, no other text.`
 	if codeContext != "" {
 		systemPrompt += "\n\nYou also have access to relevant source code from the repository. Use it to:\n- Identify specific configuration options or code paths related to the bug\n- Suggest specific debug log lines or config values the user should check\n- Provide more targeted diagnostic steps based on the actual implementation"
 	}
-	userContent := fmt.Sprintf("KNOWN ISSUES:\n%s\n\nBUG REPORT:\nTitle: %s\nBody: %s",
+	userContent := fmt.Sprintf("KNOWN ISSUES:\n%s\n\nISSUE:\nTitle: %s\nBody: %s",
 		strings.Join(summaries, "\n"), truncate(title, 200), cleanBody)
 	if codeContext != "" {
 		userContent += "\n\n" + codeContext
@@ -130,6 +136,11 @@ func stripCodeFences(text string, maxLen int) string {
 	return truncate(result, maxLen)
 }
 
+// StripCodeFences removes markdown code fences and truncates to maxLen.
+func StripCodeFences(text string, maxLen int) string {
+	return stripCodeFences(text, maxLen)
+}
+
 // truncate shortens s to at most maxLen bytes, backing up to a valid UTF-8
 // rune boundary so multi-byte sequences are never split.
 func truncate(s string, maxLen int) string {
@@ -141,6 +152,11 @@ func truncate(s string, maxLen int) string {
 		maxLen--
 	}
 	return s[:maxLen]
+}
+
+// Truncate shortens s to at most maxLen bytes at a valid UTF-8 boundary.
+func Truncate(s string, maxLen int) string {
+	return truncate(s, maxLen)
 }
 
 // extractJSONArray finds the first top-level JSON array in raw by matching

--- a/internal/phases/phase2_test.go
+++ b/internal/phases/phase2_test.go
@@ -288,7 +288,7 @@ func TestPhase2(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			results, err := Phase2(context.Background(), tt.store, tt.llm, testLogger(), "test/repo", "Test Issue", "Test body content", "")
+			results, err := Phase2(context.Background(), tt.store, tt.llm, testLogger(), "test/repo", "Test Issue", "Test body content", "", nil)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")

--- a/internal/phases/phase4a.go
+++ b/internal/phases/phase4a.go
@@ -13,15 +13,21 @@ import (
 
 // Phase4a matches enhancement requests against the feature index (roadmap, ADRs, research)
 // using vector similarity search and LLM-based semantic matching.
-func Phase4a(ctx context.Context, s store.PhaseQuerier, l llm.Provider, logger *slog.Logger, repo, title, body string) ([]ContextMatch, error) {
+func Phase4a(ctx context.Context, s store.PhaseQuerier, l llm.Provider, logger *slog.Logger, repo, title, body string, preEmbedding []float32) ([]ContextMatch, error) {
 	logger.Info("phase4a start")
 	cleanBody := stripCodeFences(body, 1500)
 	queryText := fmt.Sprintf("%s\n%s", truncate(title, 200), cleanBody)
 
-	// Get embedding for the enhancement request
-	embedding, err := l.Embed(ctx, queryText)
-	if err != nil {
-		return nil, fmt.Errorf("embed issue: %w", err)
+	// Use pre-computed embedding if provided, otherwise compute it
+	var embedding []float32
+	if len(preEmbedding) > 0 {
+		embedding = preEmbedding
+	} else {
+		var err error
+		embedding, err = l.Embed(ctx, queryText)
+		if err != nil {
+			return nil, fmt.Errorf("embed issue: %w", err)
+		}
 	}
 
 	// Find similar features/ADRs/research
@@ -44,20 +50,20 @@ func Phase4a(ctx context.Context, s store.PhaseQuerier, l llm.Provider, logger *
 	}
 
 	systemPrompt := `You are a helpful assistant for the "Teams for Linux" open source project.
-Match this enhancement request against our existing roadmap items, architecture decisions (ADRs), and research documents.
+Match this issue against our existing roadmap items, architecture decisions (ADRs), and research documents.
 
-Return a JSON array of 0-3 matches. Only include items with a meaningful connection to the enhancement request (same feature area, overlapping goals, related technical decisions).
+Return a JSON array of 0-3 matches. Only include items with a meaningful connection to the issue (same feature area, overlapping goals, related technical decisions).
 
 For each match, include:
 - "index": the item index number
 - "reason": a brief explanation using humble language ("appears related", "might be connected", "could be relevant")
-- "is_infeasible": true ONLY if the matched item has status "rejected" and the rejection reason clearly applies to this request. false otherwise.
+- "is_infeasible": true ONLY if the matched item has status "rejected" and the rejection reason clearly applies to this issue. false otherwise.
 
 Format: [{"index": 0, "reason": "We've previously investigated this area...", "is_infeasible": false}]
 
 If no items match, return: []
 Respond with ONLY valid JSON, no other text.`
-	userContent := fmt.Sprintf("EXISTING FEATURES/DECISIONS/RESEARCH:\n%s\n\nENHANCEMENT REQUEST:\nTitle: %s\nBody: %s",
+	userContent := fmt.Sprintf("EXISTING FEATURES/DECISIONS/RESEARCH:\n%s\n\nISSUE:\nTitle: %s\nBody: %s",
 		strings.Join(summaries, "\n"), truncate(title, 200), cleanBody)
 
 	raw, err := l.GenerateJSONWithSystem(ctx, systemPrompt, userContent, 0.3, 8192)

--- a/internal/phases/phase4a_test.go
+++ b/internal/phases/phase4a_test.go
@@ -211,7 +211,7 @@ func TestPhase4a(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			results, err := Phase4a(context.Background(), tt.store, tt.llm, testLogger(), "test/repo", "Enhancement Request", "Add dark mode support")
+			results, err := Phase4a(context.Background(), tt.store, tt.llm, testLogger(), "test/repo", "Enhancement Request", "Add dark mode support", nil)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -250,7 +250,7 @@ func TestPhase4a_InfeasibleWithRejectedStatus(t *testing.T) {
 		},
 	}
 
-	results, err := Phase4a(context.Background(), storeMock, llmMock, testLogger(), "test/repo", "Title", "Body")
+	results, err := Phase4a(context.Background(), storeMock, llmMock, testLogger(), "test/repo", "Title", "Body", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/phases/synthesis.go
+++ b/internal/phases/synthesis.go
@@ -1,0 +1,122 @@
+package phases
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/IsmaelMartinez/github-issue-triage-bot/internal/llm"
+)
+
+// SynthesisInput holds the inputs from all triage phases for LLM synthesis.
+type SynthesisInput struct {
+	IssueTitle    string
+	IssueBody     string
+	IsBug         bool
+	IsEnhancement bool
+	IsDocBug      bool
+	Phase1        Phase1Result
+	Phase2        []Suggestion
+	Phase4a       []ContextMatch
+}
+
+// ShouldSynthesize returns true when the phase outputs contain enough material
+// for synthesis to add value beyond what the template-based builder produces.
+func ShouldSynthesize(input SynthesisInput) bool {
+	hasPwaNote := input.IsBug && !input.IsDocBug && input.Phase1.IsPwaReproducible
+	hasPhase2 := len(input.Phase2) > 0
+	hasPhase4a := len(input.Phase4a) > 0
+	hasMissing := len(input.Phase1.MissingItems) > 0
+
+	// Nothing to synthesize at all.
+	if !hasMissing && !hasPhase2 && !hasPhase4a && !hasPwaNote {
+		return false
+	}
+
+	// Only Phase 1 output with fewer than 2 missing items and no doc matches
+	// is too simple for an LLM call — the template builder handles it fine.
+	if !hasPhase2 && !hasPhase4a && !hasPwaNote && len(input.Phase1.MissingItems) < 2 {
+		return false
+	}
+
+	return true
+}
+
+const synthesisSystemPrompt = `You are a triage assistant for the "Teams for Linux" open-source project. Write a single, concise GitHub comment responding to a new issue. Write like a knowledgeable maintainer — direct, helpful, no filler.
+
+Rules:
+- Keep the response under 1500 characters.
+- Never invent documentation links — only reference URLs from the CONTEXT below.
+- Never greet the user or sign off.
+- If context documents relate to missing information, connect them (e.g., "this looks like X, and debug logs would help confirm").
+- Use markdown sparingly: short paragraphs, a checklist only when 3+ items are missing.
+- If nothing useful was found, return exactly: EMPTY
+
+Return a JSON object with a single field "comment" containing your markdown response (or "EMPTY").`
+
+// Synthesize calls the LLM to produce a single cohesive comment from all phase
+// outputs. Returns empty string if the LLM determines there is nothing useful
+// to say.
+func Synthesize(ctx context.Context, l llm.Provider, input SynthesisInput) (string, error) {
+	userContent := buildSynthesisPrompt(input)
+
+	raw, err := l.GenerateJSONWithSystem(ctx, synthesisSystemPrompt, userContent, 0.3, 2048)
+	if err != nil {
+		return "", fmt.Errorf("synthesize: %w", err)
+	}
+
+	raw = ExtractJSONObject(raw)
+
+	var result struct {
+		Comment string `json:"comment"`
+	}
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		return "", fmt.Errorf("parse synthesis response: %w", err)
+	}
+
+	comment := strings.TrimSpace(result.Comment)
+	if comment == "" || comment == "EMPTY" {
+		return "", nil
+	}
+	return comment, nil
+}
+
+// buildSynthesisPrompt assembles the user prompt from whichever phases produced
+// output.
+func buildSynthesisPrompt(input SynthesisInput) string {
+	var b strings.Builder
+
+	b.WriteString("ISSUE:\nTitle: ")
+	b.WriteString(truncate(input.IssueTitle, 200))
+	b.WriteString("\nBody: ")
+	b.WriteString(stripCodeFences(input.IssueBody, 1500))
+	b.WriteString("\n")
+
+	// Context section from Phase 2 and Phase 4a doc matches.
+	if len(input.Phase2) > 0 || len(input.Phase4a) > 0 {
+		b.WriteString("\nCONTEXT (only use these URLs):\n")
+		for _, s := range input.Phase2 {
+			b.WriteString(fmt.Sprintf("- [%s](%s): %s\n", s.Title, s.DocURL, s.Reason))
+		}
+		for _, c := range input.Phase4a {
+			b.WriteString(fmt.Sprintf("- [%s](%s): %s\n", c.Topic, c.DocURL, c.Reason))
+		}
+	}
+
+	// Missing information from Phase 1.
+	if len(input.Phase1.MissingItems) > 0 {
+		b.WriteString("\nMISSING INFORMATION:\n")
+		for _, item := range input.Phase1.MissingItems {
+			b.WriteString(fmt.Sprintf("- %s: %s\n", item.Label, item.Detail))
+		}
+	}
+
+	// PWA note for bugs that reproduce on the web app.
+	if input.IsBug && !input.IsDocBug && input.Phase1.IsPwaReproducible {
+		b.WriteString("\nPWA NOTE: This bug also occurs on the Teams web app, suggesting a Microsoft-side issue. The Microsoft Feedback Portal URL is https://feedbackportal.microsoft.com/.\n")
+	}
+
+	b.WriteString("\nWrite a single cohesive comment.")
+	return b.String()
+}

--- a/internal/phases/synthesis_test.go
+++ b/internal/phases/synthesis_test.go
@@ -1,0 +1,363 @@
+package phases
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestShouldSynthesize(t *testing.T) {
+	tests := []struct {
+		name  string
+		input SynthesisInput
+		want  bool
+	}{
+		{
+			name:  "empty input returns false",
+			input: SynthesisInput{},
+			want:  false,
+		},
+		{
+			name: "phase1 with one missing item and no docs returns false",
+			input: SynthesisInput{
+				IsBug: true,
+				Phase1: Phase1Result{
+					MissingItems: []MissingItem{{Label: "Debug", Detail: "missing"}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "phase1 with two missing items returns true",
+			input: SynthesisInput{
+				IsBug: true,
+				Phase1: Phase1Result{
+					MissingItems: []MissingItem{
+						{Label: "Debug", Detail: "missing"},
+						{Label: "Steps", Detail: "missing"},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "phase2 only returns true",
+			input: SynthesisInput{
+				IsBug:  true,
+				Phase2: []Suggestion{{Title: "Login fix", DocURL: "https://example.com", Reason: "related"}},
+			},
+			want: true,
+		},
+		{
+			name: "phase4a only returns true",
+			input: SynthesisInput{
+				IsEnhancement: true,
+				Phase4a:       []ContextMatch{{Topic: "SSO", DocURL: "https://example.com", Reason: "related"}},
+			},
+			want: true,
+		},
+		{
+			name: "phase1 one item plus phase2 returns true",
+			input: SynthesisInput{
+				IsBug: true,
+				Phase1: Phase1Result{
+					MissingItems: []MissingItem{{Label: "Debug", Detail: "missing"}},
+				},
+				Phase2: []Suggestion{{Title: "Related", DocURL: "https://example.com", Reason: "similar"}},
+			},
+			want: true,
+		},
+		{
+			name: "pwa note only returns true",
+			input: SynthesisInput{
+				IsBug: true,
+				Phase1: Phase1Result{
+					IsPwaReproducible: true,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pwa note suppressed for doc bugs",
+			input: SynthesisInput{
+				IsBug:    true,
+				IsDocBug: true,
+				Phase1: Phase1Result{
+					IsPwaReproducible: true,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "pwa note suppressed for non-bugs",
+			input: SynthesisInput{
+				IsEnhancement: true,
+				Phase1: Phase1Result{
+					IsPwaReproducible: true,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "all phases have output returns true",
+			input: SynthesisInput{
+				IsBug: true,
+				Phase1: Phase1Result{
+					MissingItems:      []MissingItem{{Label: "Debug", Detail: "missing"}},
+					IsPwaReproducible: true,
+				},
+				Phase2:  []Suggestion{{Title: "Doc", DocURL: "https://example.com", Reason: "match"}},
+				Phase4a: []ContextMatch{{Topic: "Feature", DocURL: "https://example.com", Reason: "related"}},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ShouldSynthesize(tt.input)
+			if got != tt.want {
+				t.Errorf("ShouldSynthesize() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildSynthesisPrompt(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        SynthesisInput
+		wantContains []string
+		wantMissing  []string
+	}{
+		{
+			name: "includes issue title and body",
+			input: SynthesisInput{
+				IssueTitle: "App crashes on startup",
+				IssueBody:  "When I open the app it crashes immediately",
+			},
+			wantContains: []string{"App crashes on startup", "When I open the app"},
+		},
+		{
+			name: "includes phase2 context",
+			input: SynthesisInput{
+				IssueTitle: "Bug",
+				Phase2: []Suggestion{
+					{Title: "Login Fix", DocURL: "https://example.com/login", Reason: "same symptoms"},
+				},
+			},
+			wantContains: []string{"CONTEXT (only use these URLs)", "Login Fix", "https://example.com/login", "same symptoms"},
+		},
+		{
+			name: "includes phase4a context",
+			input: SynthesisInput{
+				IssueTitle: "Feature request",
+				Phase4a: []ContextMatch{
+					{Topic: "SSO Support", DocURL: "https://example.com/sso", Reason: "planned work"},
+				},
+			},
+			wantContains: []string{"CONTEXT (only use these URLs)", "SSO Support", "https://example.com/sso"},
+		},
+		{
+			name: "includes missing information",
+			input: SynthesisInput{
+				IssueTitle: "Bug",
+				IsBug:      true,
+				Phase1: Phase1Result{
+					MissingItems: []MissingItem{
+						{Label: "Debug console output", Detail: "Please share debug logs"},
+					},
+				},
+			},
+			wantContains: []string{"MISSING INFORMATION", "Debug console output", "Please share debug logs"},
+		},
+		{
+			name: "includes pwa note for bugs",
+			input: SynthesisInput{
+				IssueTitle: "Bug",
+				IsBug:      true,
+				Phase1: Phase1Result{
+					IsPwaReproducible: true,
+				},
+			},
+			wantContains: []string{"PWA NOTE", "feedbackportal.microsoft.com"},
+		},
+		{
+			name: "omits pwa note for doc bugs",
+			input: SynthesisInput{
+				IssueTitle: "Doc bug",
+				IsBug:      true,
+				IsDocBug:   true,
+				Phase1: Phase1Result{
+					IsPwaReproducible: true,
+				},
+			},
+			wantMissing: []string{"PWA NOTE"},
+		},
+		{
+			name: "omits context section when no docs",
+			input: SynthesisInput{
+				IssueTitle: "Bug",
+				IsBug:      true,
+				Phase1: Phase1Result{
+					MissingItems: []MissingItem{{Label: "Steps", Detail: "add steps"}},
+				},
+			},
+			wantContains: []string{"MISSING INFORMATION"},
+			wantMissing:  []string{"CONTEXT"},
+		},
+		{
+			name: "truncates long body",
+			input: SynthesisInput{
+				IssueTitle: "Bug",
+				IssueBody:  strings.Repeat("a", 3000),
+			},
+			wantContains: []string{"ISSUE:"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildSynthesisPrompt(tt.input)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("prompt should contain %q, got:\n%s", want, got)
+				}
+			}
+			for _, missing := range tt.wantMissing {
+				if strings.Contains(got, missing) {
+					t.Errorf("prompt should NOT contain %q, got:\n%s", missing, got)
+				}
+			}
+		})
+	}
+}
+
+func TestSynthesize(t *testing.T) {
+	tests := []struct {
+		name       string
+		llmResp    string
+		llmErr     error
+		want       string
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name:    "normal response",
+			llmResp: `{"comment": "This looks like a login issue. Try clearing the cache."}`,
+			want:    "This looks like a login issue. Try clearing the cache.",
+		},
+		{
+			name:    "EMPTY response returns empty string",
+			llmResp: `{"comment": "EMPTY"}`,
+			want:    "",
+		},
+		{
+			name:    "empty comment field returns empty string",
+			llmResp: `{"comment": ""}`,
+			want:    "",
+		},
+		{
+			name:    "whitespace-only comment returns empty string",
+			llmResp: `{"comment": "   "}`,
+			want:    "",
+		},
+		{
+			name:       "LLM error propagates",
+			llmErr:     context.DeadlineExceeded,
+			wantErr:    true,
+			wantErrMsg: "synthesize",
+		},
+		{
+			name:    "non-JSON response falls back to empty via ExtractJSONObject",
+			llmResp: `not json at all`,
+			want:    "",
+		},
+		{
+			name:    "response with extra whitespace is trimmed",
+			llmResp: `{"comment": "\n  Check the debug logs.  \n"}`,
+			want:    "Check the debug logs.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockProvider{
+				generateJSONWithSysFunc: func(ctx context.Context, sys, user string, temp float64, max int) (string, error) {
+					if tt.llmErr != nil {
+						return "", tt.llmErr
+					}
+					return tt.llmResp, nil
+				},
+			}
+
+			input := SynthesisInput{
+				IssueTitle: "Test issue",
+				IssueBody:  "Test body",
+				IsBug:      true,
+				Phase1: Phase1Result{
+					MissingItems: []MissingItem{{Label: "Debug", Detail: "add logs"}},
+				},
+				Phase2: []Suggestion{{Title: "Doc", DocURL: "https://example.com", Reason: "related"}},
+			}
+
+			got, err := Synthesize(context.Background(), mock, input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErrMsg) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.wantErrMsg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSynthesizePromptParameters(t *testing.T) {
+	var capturedSys, capturedUser string
+	var capturedTemp float64
+	var capturedMax int
+
+	mock := &mockProvider{
+		generateJSONWithSysFunc: func(ctx context.Context, sys, user string, temp float64, max int) (string, error) {
+			capturedSys = sys
+			capturedUser = user
+			capturedTemp = temp
+			capturedMax = max
+			return `{"comment": "ok"}`, nil
+		},
+	}
+
+	input := SynthesisInput{
+		IssueTitle: "Test",
+		IssueBody:  "Body",
+		IsBug:      true,
+		Phase2:     []Suggestion{{Title: "Doc", DocURL: "https://example.com", Reason: "match"}},
+	}
+
+	_, err := Synthesize(context.Background(), mock, input)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedTemp != 0.3 {
+		t.Errorf("temperature = %v, want 0.3", capturedTemp)
+	}
+	if capturedMax != 2048 {
+		t.Errorf("maxTokens = %d, want 2048", capturedMax)
+	}
+	if !strings.Contains(capturedSys, "triage assistant") {
+		t.Error("system prompt should contain 'triage assistant'")
+	}
+	if !strings.Contains(capturedUser, "CONTEXT") {
+		t.Error("user prompt should contain CONTEXT section when Phase2 has results")
+	}
+}

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -399,16 +399,6 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 		issueLog.Info("using source repo for data lookups", "dataRepo", dataRepo)
 	}
 
-	// Compute embedding once for reuse across phases
-	cleanBody := phases.StripCodeFences(issue.Body, 1500)
-	queryText := fmt.Sprintf("%s\n%s", phases.Truncate(issue.Title, 200), cleanBody)
-	embedding, embedErr := h.llm.Embed(ctx, queryText)
-	if embedErr != nil {
-		issueLog.Warn("embedding failed, LLM phases will compute their own", "error", embedErr)
-		// Pass nil so phases fall back to their own embed calls (which may also fail).
-		embedding = nil
-	}
-
 	// Determine issue type
 	isBug := hasLabel(issue.Labels, "bug")
 	isEnhancement := hasLabel(issue.Labels, "enhancement")
@@ -420,6 +410,7 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 	result.IsEnhancement = isEnhancement
 	result.IsDocBug = isBug && isDocumentationBug(issue.Title)
 	var phaseErrors []string // track LLM phase errors for shadow-mode fallback
+	var embedding []float32
 
 	if !cfg.Capabilities.Triage {
 		issueLog.Info("triage capability disabled, skipping phases")
@@ -428,6 +419,16 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 	// Phase 1: Missing info (always runs when triage enabled)
 	if cfg.Capabilities.Triage {
 		result.Phase1 = phases.Phase1(issue.Body)
+
+		// Compute embedding once for reuse across Phase 2 and Phase 4a
+		cleanBody := phases.StripCodeFences(issue.Body, 1500)
+		queryText := fmt.Sprintf("%s\n%s", phases.Truncate(issue.Title, 200), cleanBody)
+		var embedErr error
+		embedding, embedErr = h.llm.Embed(ctx, queryText)
+		if embedErr != nil {
+			issueLog.Warn("embedding failed, LLM phases will compute their own", "error", embedErr)
+			embedding = nil
+		}
 	}
 
 	// Code navigation: fetch relevant source files for Phase 2 context (bugs only)
@@ -587,6 +588,17 @@ func (h *Handler) handleRetriage(ctx context.Context, installationID int64, repo
 		dataRepo = h.sourceRepo
 	}
 
+	isBug := hasLabel(issue.Labels, "bug")
+	isEnhancement := hasLabel(issue.Labels, "enhancement")
+
+	var result comment.TriageResult
+	result.IsBug = isBug
+	result.IsEnhancement = isEnhancement
+	result.IsDocBug = isBug && isDocumentationBug(issue.Title)
+	var phaseErrors []string
+
+	result.Phase1 = phases.Phase1(issue.Body)
+
 	// Compute embedding once for reuse across phases
 	cleanBody := phases.StripCodeFences(issue.Body, 1500)
 	queryText := fmt.Sprintf("%s\n%s", phases.Truncate(issue.Title, 200), cleanBody)
@@ -596,25 +608,17 @@ func (h *Handler) handleRetriage(ctx context.Context, installationID int64, repo
 		embedding = nil
 	}
 
-	isBug := hasLabel(issue.Labels, "bug")
-	isEnhancement := hasLabel(issue.Labels, "enhancement")
-
-	var result comment.TriageResult
-	result.IsBug = isBug
-	result.IsEnhancement = isEnhancement
-	result.IsDocBug = isBug && isDocumentationBug(issue.Title)
-
-	result.Phase1 = phases.Phase1(issue.Body)
-
 	p2, err := phases.Phase2(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body, "", embedding)
 	if err != nil {
 		issueLog.Error("retriage phase 2 failed", "error", err)
+		phaseErrors = append(phaseErrors, fmt.Sprintf("Phase 2: %s", err.Error()))
 	}
 	result.Phase2 = p2
 
 	p4a, err := phases.Phase4a(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body, embedding)
 	if err != nil {
 		issueLog.Error("retriage phase 4a failed", "error", err)
+		phaseErrors = append(phaseErrors, fmt.Sprintf("Phase 4a: %s", err.Error()))
 	}
 	result.Phase4a = p4a
 
@@ -653,8 +657,29 @@ func (h *Handler) handleRetriage(ctx context.Context, installationID int64, repo
 	phasesRun := collectPhasesRun(result, synthesized)
 
 	shadowRepo, ok := h.shadowRepos[repo]
-	if !ok || body == "" {
-		issueLog.Info("retriage produced no output or no shadow repo configured")
+	if !ok {
+		issueLog.Info("no shadow repo configured for retriage")
+		return
+	}
+	if body == "" && len(phaseErrors) > 0 {
+		// Phases errored but nothing to show — create error-note shadow issue
+		const totalSections = 4
+		filled := totalSections - len(result.Phase1.MissingItems)
+		shadowTitle := fmt.Sprintf("[Retriage] [%d/%d] #%d: %s", filled, totalSections, issue.Number, issue.Title)
+		shadowBody := gh.FormatShadowIssueBody(repo, issue.Number, issue.Title, issue.Body)
+		shadowNumber, createErr := h.github.CreateIssue(ctx, installationID, shadowRepo, shadowTitle, shadowBody)
+		if createErr != nil {
+			issueLog.Error("creating retriage error shadow issue", "error", createErr)
+			return
+		}
+		errNote := fmt.Sprintf("**Note:** Retriage was incomplete due to errors. LLM-powered phases could not run.\n\n<details><summary>Errors</summary>\n\n%s\n\n</details>\n\n*Reply `/retriage` on the source issue to retry.*", strings.Join(phaseErrors, "\n"))
+		if _, err := h.github.CreateComment(ctx, installationID, shadowRepo, shadowNumber, errNote); err != nil {
+			issueLog.Error("posting retriage error note", "error", err)
+		}
+		return
+	}
+	if body == "" {
+		issueLog.Info("retriage produced no output")
 		return
 	}
 

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -399,6 +399,14 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 		issueLog.Info("using source repo for data lookups", "dataRepo", dataRepo)
 	}
 
+	// Compute embedding once for reuse across phases
+	cleanBody := phases.StripCodeFences(issue.Body, 1500)
+	queryText := fmt.Sprintf("%s\n%s", phases.Truncate(issue.Title, 200), cleanBody)
+	embedding, embedErr := h.llm.Embed(ctx, queryText)
+	if embedErr != nil {
+		issueLog.Error("embedding issue", "error", embedErr)
+	}
+
 	// Determine issue type
 	isBug := hasLabel(issue.Labels, "bug")
 	isEnhancement := hasLabel(issue.Labels, "enhancement")
@@ -431,9 +439,9 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 		}
 	}
 
-	// Phase 2: Solution suggestions (bugs only)
-	if isBug && cfg.Capabilities.Triage {
-		p2, err := phases.Phase2(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body, codeCtx)
+	// Phase 2: Solution suggestions
+	if cfg.Capabilities.Triage {
+		p2, err := phases.Phase2(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body, codeCtx, embedding)
 		if err != nil {
 			issueLog.Error("phase 2 failed", "error", err)
 			phaseErrors = append(phaseErrors, fmt.Sprintf("Phase 2: %s", err.Error()))
@@ -442,9 +450,9 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 		result.Phase2 = p2
 	}
 
-	// Phase 4a: Enhancement context (enhancements only)
-	if isEnhancement && cfg.Capabilities.Triage {
-		p4a, err := phases.Phase4a(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body)
+	// Phase 4a: Enhancement context
+	if cfg.Capabilities.Triage {
+		p4a, err := phases.Phase4a(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body, embedding)
 		if err != nil {
 			issueLog.Error("phase 4a failed", "error", err)
 			phaseErrors = append(phaseErrors, fmt.Sprintf("Phase 4a: %s", err.Error()))
@@ -453,9 +461,34 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 		result.Phase4a = p4a
 	}
 
-	// Build triage comment
-	body := comment.Build(result)
-	phasesRun := collectPhasesRun(result)
+	// Build triage comment — try synthesis first, fall back to concatenation
+	synthInput := phases.SynthesisInput{
+		IssueTitle:    issue.Title,
+		IssueBody:     issue.Body,
+		IsBug:         isBug,
+		IsEnhancement: isEnhancement,
+		IsDocBug:      result.IsDocBug,
+		Phase1:        result.Phase1,
+		Phase2:        result.Phase2,
+		Phase4a:       result.Phase4a,
+	}
+
+	var synthesized bool
+	var body string
+	if phases.ShouldSynthesize(synthInput) {
+		synthResult, synthErr := phases.Synthesize(ctx, h.llm, synthInput)
+		if synthErr != nil {
+			issueLog.Error("synthesis failed, falling back to concatenation", "error", synthErr)
+			body = comment.Build(result)
+		} else if synthResult != "" {
+			body = synthResult
+			synthesized = true
+		}
+	}
+	if body == "" {
+		body = comment.Build(result)
+	}
+	phasesRun := collectPhasesRun(result, synthesized)
 
 	if shadowRepo, ok := h.shadowRepos[repo]; ok && body != "" {
 		// Post to shadow repo for review
@@ -547,6 +580,14 @@ func (h *Handler) handleRetriage(ctx context.Context, installationID int64, repo
 		dataRepo = h.sourceRepo
 	}
 
+	// Compute embedding once for reuse across phases
+	cleanBody := phases.StripCodeFences(issue.Body, 1500)
+	queryText := fmt.Sprintf("%s\n%s", phases.Truncate(issue.Title, 200), cleanBody)
+	embedding, embedErr := h.llm.Embed(ctx, queryText)
+	if embedErr != nil {
+		issueLog.Error("embedding issue", "error", embedErr)
+	}
+
 	isBug := hasLabel(issue.Labels, "bug")
 	isEnhancement := hasLabel(issue.Labels, "enhancement")
 
@@ -557,24 +598,46 @@ func (h *Handler) handleRetriage(ctx context.Context, installationID int64, repo
 
 	result.Phase1 = phases.Phase1(issue.Body)
 
-	if isBug {
-		p2, err := phases.Phase2(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body, "")
-		if err != nil {
-			issueLog.Error("retriage phase 2 failed", "error", err)
-		}
-		result.Phase2 = p2
+	p2, err := phases.Phase2(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body, "", embedding)
+	if err != nil {
+		issueLog.Error("retriage phase 2 failed", "error", err)
+	}
+	result.Phase2 = p2
+
+	p4a, err := phases.Phase4a(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body, embedding)
+	if err != nil {
+		issueLog.Error("retriage phase 4a failed", "error", err)
+	}
+	result.Phase4a = p4a
+
+	// Build triage comment — try synthesis first, fall back to concatenation
+	synthInput := phases.SynthesisInput{
+		IssueTitle:    issue.Title,
+		IssueBody:     issue.Body,
+		IsBug:         isBug,
+		IsEnhancement: isEnhancement,
+		IsDocBug:      result.IsDocBug,
+		Phase1:        result.Phase1,
+		Phase2:        result.Phase2,
+		Phase4a:       result.Phase4a,
 	}
 
-	if isEnhancement {
-		p4a, err := phases.Phase4a(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body)
-		if err != nil {
-			issueLog.Error("retriage phase 4a failed", "error", err)
+	var synthesized bool
+	var body string
+	if phases.ShouldSynthesize(synthInput) {
+		synthResult, synthErr := phases.Synthesize(ctx, h.llm, synthInput)
+		if synthErr != nil {
+			issueLog.Error("synthesis failed, falling back to concatenation", "error", synthErr)
+			body = comment.Build(result)
+		} else if synthResult != "" {
+			body = synthResult
+			synthesized = true
 		}
-		result.Phase4a = p4a
 	}
-
-	body := comment.Build(result)
-	phasesRun := collectPhasesRun(result)
+	if body == "" {
+		body = comment.Build(result)
+	}
+	phasesRun := collectPhasesRun(result, synthesized)
 
 	shadowRepo, ok := h.shadowRepos[repo]
 	if !ok || body == "" {
@@ -866,7 +929,7 @@ func sanitizeBody(body string, maxLen int) string {
 	return result
 }
 
-func collectPhasesRun(r comment.TriageResult) []string {
+func collectPhasesRun(r comment.TriageResult, synthesized bool) []string {
 	var phases []string
 	phases = append(phases, "missing_info")
 	if r.Phase2 != nil {
@@ -874,6 +937,9 @@ func collectPhasesRun(r comment.TriageResult) []string {
 	}
 	if r.Phase4a != nil {
 		phases = append(phases, "enhancement_context")
+	}
+	if synthesized {
+		phases = append(phases, "synthesis")
 	}
 	return phases
 }

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -404,7 +404,9 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 	queryText := fmt.Sprintf("%s\n%s", phases.Truncate(issue.Title, 200), cleanBody)
 	embedding, embedErr := h.llm.Embed(ctx, queryText)
 	if embedErr != nil {
-		issueLog.Error("embedding issue", "error", embedErr)
+		issueLog.Warn("embedding failed, LLM phases will compute their own", "error", embedErr)
+		// Pass nil so phases fall back to their own embed calls (which may also fail).
+		embedding = nil
 	}
 
 	// Determine issue type
@@ -481,7 +483,12 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 			issueLog.Error("synthesis failed, falling back to concatenation", "error", synthErr)
 			body = comment.Build(result)
 		} else if synthResult != "" {
-			body = synthResult
+			// Sanitise LLM output, append debug instructions and footer
+			body = comment.SanitizeLLMOutput(synthResult)
+			if di := comment.DebugInstructions(result); di != "" {
+				body += "\n\n" + di
+			}
+			body += "\n\n" + comment.Footer(result)
 			synthesized = true
 		}
 	}
@@ -585,7 +592,8 @@ func (h *Handler) handleRetriage(ctx context.Context, installationID int64, repo
 	queryText := fmt.Sprintf("%s\n%s", phases.Truncate(issue.Title, 200), cleanBody)
 	embedding, embedErr := h.llm.Embed(ctx, queryText)
 	if embedErr != nil {
-		issueLog.Error("embedding issue", "error", embedErr)
+		issueLog.Warn("embedding failed, LLM phases will compute their own", "error", embedErr)
+		embedding = nil
 	}
 
 	isBug := hasLabel(issue.Labels, "bug")
@@ -630,7 +638,12 @@ func (h *Handler) handleRetriage(ctx context.Context, installationID int64, repo
 			issueLog.Error("synthesis failed, falling back to concatenation", "error", synthErr)
 			body = comment.Build(result)
 		} else if synthResult != "" {
-			body = synthResult
+			// Sanitise LLM output, append debug instructions and footer
+			body = comment.SanitizeLLMOutput(synthResult)
+			if di := comment.DebugInstructions(result); di != "" {
+				body += "\n\n" + di
+			}
+			body += "\n\n" + comment.Footer(result)
 			synthesized = true
 		}
 	}

--- a/internal/webhook/handler_test.go
+++ b/internal/webhook/handler_test.go
@@ -140,7 +140,7 @@ func TestCollectPhasesRun(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := collectPhasesRun(tt.result)
+			got := collectPhasesRun(tt.result, false)
 			if len(got) != len(tt.want) {
 				t.Fatalf("collectPhasesRun() returned %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
## Summary

- Run all phases (1, 2, 4a) for every issue regardless of labels
- Share one embedding call across Phase 2 and Phase 4a (saves ~20% LLM budget)
- Add synthesis LLM step that composes phase outputs into one coherent response
- Fall back to concatenated comment.Build() on synthesis failure
- Fix unlabelled issues silently dropping Phase 2 results
- Generalise Phase 2/4a prompts from "bug report"/"enhancement request" to "issue"

The core problem: phases ran independently and the comment builder concatenated their outputs into disconnected sections. A human maintainer would weave these together — "this looks like [doc X], and debug logs would help confirm." The synthesis step does this via one additional LLM call.

The ShouldSynthesize guard skips the LLM call for trivially simple cases (single missing item, no doc matches), so simple issues still use the fast deterministic path.

## Test plan

- [ ] `go test ./...` passes (21 packages)
- [ ] `go vet ./...` clean
- [ ] `go build ./...` clean
- [ ] Verify synthesis output in shadow repo for next real issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LLM-based comment synthesis added for cohesive triage responses; synthesis runs when sufficient context exists.

* **Improvements**
  * Triage phases now run for all issues; shared precomputed embeddings speed up/contextualize phase processing and gracefully fall back on embed failure.
  * Footer selection now adapts to which analysis produced results.
  * Sanitization of LLM output exposed for reuse; debug instructions shown for qualifying bug reports.

* **Tests**
  * Expanded unit tests covering synthesis, prompt construction, and phase behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->