### PR TITLE
feat: parameterize all LLM prompts and bot output via butler.json ProjectMeta

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ The Gemini API client uses the REST API directly rather than an SDK to minimize 
 
 Phase 1 is pure string parsing (no network calls) and has the most comprehensive test coverage. The LLM phases are harder to unit test since they depend on Gemini's output format; they use extractJSONArray/ExtractJSONObject helpers with fallback parsing. All LLM JSON responses must be passed through `phases.ExtractJSONObject()` before `json.Unmarshal`, even when using `responseMimeType: application/json`, as a defensive measure against code-fenced or prefixed responses.
 
-The comment builder produces concise output: a single-sentence preamble, no greeting line, a compact footer with a feedback hint. Keep builder output minimal.
+The comment builder produces concise output: a single-sentence preamble, no greeting line, a compact footer with a feedback hint. Keep builder output minimal. All LLM prompts and bot output (debug command, doc links, project name) are parameterized via `config.ProjectMeta` in the per-repo butler.json `project` field. Defaults match the teams-for-linux deployment.
 
 Environment variables: DATABASE_URL (required), GEMINI_API_KEY (optional, warns if missing), GITHUB_APP_ID (required, numeric App ID), GITHUB_PRIVATE_KEY (required, base64-encoded or raw PEM), WEBHOOK_SECRET (required), SOURCE_REPO (optional, overrides repo for vector searches), SHADOW_REPOS (optional, comma-separated "owner/repo:owner/shadow" mappings for agent sessions), INGEST_SECRET (optional, authenticates /ingest and /synthesize endpoints; empty disables auth), PORT (optional, defaults to 8080). The cmd/sync-reactions tool uses REPO (optional, defaults to IsmaelMartinez/teams-for-linux) to select which repository's comments to sync.
 

--- a/cmd/backfill/main.go
+++ b/cmd/backfill/main.go
@@ -92,13 +92,13 @@ func main() {
 			preEmbedding = nil
 		}
 
-		p2, err := phases.Phase2(ctx, s, llmClient, issLog, dataRepo, iss.Title, iss.Body, "", preEmbedding)
+		p2, err := phases.Phase2(ctx, s, llmClient, issLog, dataRepo, iss.Title, iss.Body, "", preEmbedding, "")
 		if err != nil {
 			issLog.Error("phase 2 failed", "error", err)
 		}
 		result.Phase2 = p2
 
-		p4a, err := phases.Phase4a(ctx, s, llmClient, issLog, dataRepo, iss.Title, iss.Body, preEmbedding)
+		p4a, err := phases.Phase4a(ctx, s, llmClient, issLog, dataRepo, iss.Title, iss.Body, preEmbedding, "")
 		if err != nil {
 			issLog.Error("phase 4a failed", "error", err)
 		}

--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -17,12 +17,14 @@ import (
 // AgentHandler manages the enhancement research agent lifecycle,
 // coordinating between shadow repos, LLM analysis, and human review.
 type AgentHandler struct {
-	store      *store.Store
-	llm        llm.Provider
-	github     *gh.Client
-	structural *safety.StructuralValidator
-	llmSafety  *safety.LLMValidator
-	logger     *slog.Logger
+	store              *store.Store
+	llm                llm.Provider
+	github             *gh.Client
+	structural         *safety.StructuralValidator
+	llmSafety          *safety.LLMValidator
+	logger             *slog.Logger
+	projectName        string // from butler.json Project.Name
+	projectDescription string // from butler.json Project.Description
 }
 
 // NewAgentHandler creates a new AgentHandler with all required dependencies.
@@ -35,6 +37,12 @@ func NewAgentHandler(s *store.Store, l llm.Provider, g *gh.Client, structural *s
 		llmSafety:  llmSafety,
 		logger:     logger,
 	}
+}
+
+// SetProjectMeta configures the project name and description used in LLM prompts.
+func (h *AgentHandler) SetProjectMeta(name, description string) {
+	h.projectName = name
+	h.projectDescription = description
 }
 
 // StartSession creates a mirror issue in the shadow repo and posts a context
@@ -193,7 +201,7 @@ func (h *AgentHandler) startResearch(ctx context.Context, installationID, sessio
 	}
 
 	// Synthesize research
-	doc, err := SynthesizeResearch(ctx, h.llm, title, researchBody, docSummaries, issueSummaries)
+	doc, err := SynthesizeResearch(ctx, h.llm, title, researchBody, docSummaries, issueSummaries, h.projectName, h.projectDescription)
 	if err != nil {
 		return fmt.Errorf("synthesize research: %w", err)
 	}

--- a/internal/agent/handler.go
+++ b/internal/agent/handler.go
@@ -17,14 +17,12 @@ import (
 // AgentHandler manages the enhancement research agent lifecycle,
 // coordinating between shadow repos, LLM analysis, and human review.
 type AgentHandler struct {
-	store              *store.Store
-	llm                llm.Provider
-	github             *gh.Client
-	structural         *safety.StructuralValidator
-	llmSafety          *safety.LLMValidator
-	logger             *slog.Logger
-	projectName        string // from butler.json Project.Name
-	projectDescription string // from butler.json Project.Description
+	store      *store.Store
+	llm        llm.Provider
+	github     *gh.Client
+	structural *safety.StructuralValidator
+	llmSafety  *safety.LLMValidator
+	logger     *slog.Logger
 }
 
 // NewAgentHandler creates a new AgentHandler with all required dependencies.
@@ -39,16 +37,10 @@ func NewAgentHandler(s *store.Store, l llm.Provider, g *gh.Client, structural *s
 	}
 }
 
-// SetProjectMeta configures the project name and description used in LLM prompts.
-func (h *AgentHandler) SetProjectMeta(name, description string) {
-	h.projectName = name
-	h.projectDescription = description
-}
-
 // StartSession creates a mirror issue in the shadow repo and posts a context
 // brief summarising related documents and issues. Maintainers can then reply
 // with "research" to trigger full synthesis, or "reject" to close the session.
-func (h *AgentHandler) StartSession(ctx context.Context, installationID int64, sourceRepo string, issueNumber int, shadowRepo string, title, body string) error {
+func (h *AgentHandler) StartSession(ctx context.Context, installationID int64, sourceRepo string, issueNumber int, shadowRepo string, title, body string, projectName, projectDescription string) error {
 	log := h.logger.With("sourceRepo", sourceRepo, "issue", issueNumber, "shadowRepo", shadowRepo)
 
 	// Create mirror issue in shadow repo
@@ -62,7 +54,7 @@ func (h *AgentHandler) StartSession(ctx context.Context, installationID int64, s
 
 	// Run the rest of the session setup, posting error feedback on the shadow
 	// issue if anything fails after issue creation.
-	if err := h.startSessionAfterCreate(ctx, installationID, sourceRepo, issueNumber, shadowRepo, shadowNumber, title, body, log); err != nil {
+	if err := h.startSessionAfterCreate(ctx, installationID, sourceRepo, issueNumber, shadowRepo, shadowNumber, title, body, projectName, projectDescription, log); err != nil {
 		errMsg := fmt.Sprintf("Something went wrong setting up the context brief. A maintainer can trigger a retry with `/retriage`.\n\n<details><summary>Error details</summary>\n\n```\n%s\n```\n</details>", err.Error())
 		if _, postErr := h.github.CreateComment(ctx, installationID, shadowRepo, shadowNumber, errMsg); postErr != nil {
 			log.Error("failed to post error feedback on shadow issue", "error", postErr)
@@ -77,15 +69,15 @@ func (h *AgentHandler) retryContextBrief(ctx context.Context, installationID int
 	return h.buildAndPostContextBrief(ctx, installationID, sess.ID, sess.Repo, sess.IssueNumber, sess.ShadowRepo, sess.ShadowIssueNumber, title, body, log)
 }
 
-func (h *AgentHandler) startSessionAfterCreate(ctx context.Context, installationID int64, sourceRepo string, issueNumber int, shadowRepo string, shadowNumber int, title, body string, log *slog.Logger) error {
-	// Create session
+func (h *AgentHandler) startSessionAfterCreate(ctx context.Context, installationID int64, sourceRepo string, issueNumber int, shadowRepo string, shadowNumber int, title, body string, projectName, projectDescription string, log *slog.Logger) error {
+	// Create session — store project metadata in context for later use by HandleComment
 	sessionID, err := h.store.CreateSession(ctx, store.AgentSession{
 		Repo:              sourceRepo,
 		IssueNumber:       issueNumber,
 		ShadowRepo:        shadowRepo,
 		ShadowIssueNumber: shadowNumber,
 		Stage:             store.StageNew,
-		Context:           map[string]any{"title": title, "body": body},
+		Context:           map[string]any{"title": title, "body": body, "project_name": projectName, "project_description": projectDescription},
 	})
 	if err != nil {
 		return fmt.Errorf("create session: %w", err)
@@ -160,7 +152,7 @@ func (h *AgentHandler) buildAndPostContextBrief(ctx context.Context, installatio
 	return nil
 }
 
-func (h *AgentHandler) startResearch(ctx context.Context, installationID, sessionID int64, shadowRepo string, shadowNumber int, sourceRepo string, issueNumber int, title, body string, clarificationAnswers []string, roundTrips ...int) error {
+func (h *AgentHandler) startResearch(ctx context.Context, installationID, sessionID int64, shadowRepo string, shadowNumber int, sourceRepo string, issueNumber int, title, body string, clarificationAnswers []string, projectName, projectDescription string, roundTrips ...int) error {
 	// Preserve round-trip count if provided (default 0 for initial research)
 	currentRoundTrips := 0
 	if len(roundTrips) > 0 {
@@ -201,7 +193,7 @@ func (h *AgentHandler) startResearch(ctx context.Context, installationID, sessio
 	}
 
 	// Synthesize research
-	doc, err := SynthesizeResearch(ctx, h.llm, title, researchBody, docSummaries, issueSummaries, h.projectName, h.projectDescription)
+	doc, err := SynthesizeResearch(ctx, h.llm, title, researchBody, docSummaries, issueSummaries, projectName, projectDescription)
 	if err != nil {
 		return fmt.Errorf("synthesize research: %w", err)
 	}
@@ -389,7 +381,8 @@ func (h *AgentHandler) handleContextBriefResponse(ctx context.Context, installat
 		log.Info("research requested, starting full research pipeline")
 		title, _ := sess.Context["title"].(string)
 		body, _ := sess.Context["body"].(string)
-		return h.startResearch(ctx, installationID, sess.ID, sess.ShadowRepo, sess.ShadowIssueNumber, sess.Repo, sess.IssueNumber, title, body, nil)
+		pName, pDesc := sessionProjectMeta(sess)
+		return h.startResearch(ctx, installationID, sess.ID, sess.ShadowRepo, sess.ShadowIssueNumber, sess.Repo, sess.IssueNumber, title, body, nil, pName, pDesc)
 
 	case SignalUseAsContext:
 		log.Info("context brief acknowledged, closing session")
@@ -416,8 +409,9 @@ func (h *AgentHandler) handleContextBriefResponse(ctx context.Context, installat
 		log.Info("feedback on context brief, starting research with additional context")
 		title, _ := sess.Context["title"].(string)
 		body, _ := sess.Context["body"].(string)
+		pName, pDesc := sessionProjectMeta(sess)
 		feedback := []string{commentBody}
-		return h.startResearch(ctx, installationID, sess.ID, sess.ShadowRepo, sess.ShadowIssueNumber, sess.Repo, sess.IssueNumber, title, body, feedback)
+		return h.startResearch(ctx, installationID, sess.ID, sess.ShadowRepo, sess.ShadowIssueNumber, sess.Repo, sess.IssueNumber, title, body, feedback, pName, pDesc)
 	}
 }
 
@@ -449,9 +443,10 @@ func (h *AgentHandler) handleClarifyingResponse(ctx context.Context, installatio
 	// Enrich body with clarification and proceed to research
 	title, _ := sess.Context["title"].(string)
 	body, _ := sess.Context["body"].(string)
+	pName, pDesc := sessionProjectMeta(sess)
 	answers := []string{commentBody}
 
-	return h.startResearch(ctx, installationID, sess.ID, sess.ShadowRepo, sess.ShadowIssueNumber, sess.Repo, sess.IssueNumber, title, body, answers, sess.RoundTripCount)
+	return h.startResearch(ctx, installationID, sess.ID, sess.ShadowRepo, sess.ShadowIssueNumber, sess.Repo, sess.IssueNumber, title, body, answers, pName, pDesc, sess.RoundTripCount)
 }
 
 func (h *AgentHandler) handleReviewResponse(ctx context.Context, installationID int64, sess *store.AgentSession, signal ApprovalSignal, commentBody string, commentUser string, log *slog.Logger) error {
@@ -484,8 +479,9 @@ func (h *AgentHandler) handleReviewResponse(ctx context.Context, installationID 
 		}
 		title, _ := sess.Context["title"].(string)
 		body, _ := sess.Context["body"].(string)
+		pName, pDesc := sessionProjectMeta(sess)
 		feedback := []string{commentBody}
-		return h.startResearch(ctx, installationID, sess.ID, sess.ShadowRepo, sess.ShadowIssueNumber, sess.Repo, sess.IssueNumber, title, body, feedback, newRoundTrips)
+		return h.startResearch(ctx, installationID, sess.ID, sess.ShadowRepo, sess.ShadowIssueNumber, sess.Repo, sess.IssueNumber, title, body, feedback, pName, pDesc, newRoundTrips)
 
 	case SignalPromote:
 		if gate != nil {
@@ -510,8 +506,9 @@ func (h *AgentHandler) handleReviewResponse(ctx context.Context, installationID 
 		}
 		title, _ := sess.Context["title"].(string)
 		body, _ := sess.Context["body"].(string)
+		pName, pDesc := sessionProjectMeta(sess)
 		feedback := []string{commentBody}
-		return h.startResearch(ctx, installationID, sess.ID, sess.ShadowRepo, sess.ShadowIssueNumber, sess.Repo, sess.IssueNumber, title, body, feedback, newRoundTrips)
+		return h.startResearch(ctx, installationID, sess.ID, sess.ShadowRepo, sess.ShadowIssueNumber, sess.Repo, sess.IssueNumber, title, body, feedback, pName, pDesc, newRoundTrips)
 	}
 }
 
@@ -633,6 +630,13 @@ func (h *AgentHandler) handlePromote(ctx context.Context, installationID int64, 
 
 	log.Info("promoted research to public issue")
 	return nil
+}
+
+// sessionProjectMeta extracts project name and description from session context.
+func sessionProjectMeta(sess *store.AgentSession) (string, string) {
+	name, _ := sess.Context["project_name"].(string)
+	desc, _ := sess.Context["project_description"].(string)
+	return name, desc
 }
 
 // hashString returns the first 8 bytes of the SHA-256 hash of s as hex.

--- a/internal/agent/integration_test.go
+++ b/internal/agent/integration_test.go
@@ -80,7 +80,7 @@ func TestEnhancementResearchFlow_SkipClarification(t *testing.T) {
 	}
 
 	// Phase 2: Synthesize research (since clarification was skipped)
-	doc, err := SynthesizeResearch(ctx, mock, "Add Ctrl+M mute toggle", "When in a call, pressing Ctrl+M should toggle mute.", nil, nil)
+	doc, err := SynthesizeResearch(ctx, mock, "Add Ctrl+M mute toggle", "When in a call, pressing Ctrl+M should toggle mute.", nil, nil, "", "")
 	if err != nil {
 		t.Fatalf("SynthesizeResearch: %v", err)
 	}

--- a/internal/agent/research.go
+++ b/internal/agent/research.go
@@ -56,17 +56,18 @@ Respond with JSON matching this schema:
 Set confidence to how confident you are that you understand the request (1.0 = perfectly clear, 0.0 = completely unclear).
 If needs_clarification is false, questions should be an empty array.`
 
-const synthesizeResearchSystemPrompt = `You are a software engineering researcher for teams-for-linux, an Electron desktop wrapper around the Microsoft Teams web app.
+func synthesizeResearchSystemPrompt(projectName, projectDescription string) string {
+	if projectName == "" {
+		projectName = "the project"
+	}
+	header := fmt.Sprintf("You are a software engineering researcher for %s", projectName)
+	if projectDescription != "" {
+		header += ", " + projectDescription
+	}
+	header += "."
+	return header + `
 
-Project architecture:
-- Desktop client: Electron + Node.js wrapping the Teams web app in a BrowserWindow
-- Custom CSS injection for theming (user-provided CSS files loaded at startup)
-- Configuration via config.json and CLI flags (Electron flags, proxy, notifications, etc.)
-- System tray integration, notifications, and keyboard shortcuts via Electron APIs
-- Preload scripts for bridging web app and native features
-- The app cannot modify the Teams web UI itself — features must work through Electron APIs, CSS injection, or configuration
-
-Given an enhancement request and related context (similar issues, ADRs, past research), produce a research document that evaluates implementation approaches grounded in this architecture. Reference related ADRs or past issues when relevant.
+Given an enhancement request and related context (similar issues, ADRs, past research), produce a research document that evaluates implementation approaches grounded in the project's architecture. Reference related ADRs or past issues when relevant.
 
 Generate 2-3 distinct approaches with trade-offs. Be specific and actionable.
 
@@ -78,6 +79,7 @@ Respond with JSON matching this schema:
   "recommendation": "string",
   "open_questions": ["string"]
 }`
+}
 
 // AnalyzeEnhancement uses an LLM to determine if an enhancement request has
 // enough detail to proceed with research, returning clarifying questions if not.
@@ -99,7 +101,7 @@ func AnalyzeEnhancement(ctx context.Context, provider llm.Provider, title, body 
 
 // SynthesizeResearch uses an LLM to produce a research document with multiple
 // implementation approaches, trade-offs, and a recommendation.
-func SynthesizeResearch(ctx context.Context, provider llm.Provider, title, body string, relatedDocs []string, relatedIssues []string) (*ResearchDocument, error) {
+func SynthesizeResearch(ctx context.Context, provider llm.Provider, title, body string, relatedDocs []string, relatedIssues []string, projectName, projectDescription string) (*ResearchDocument, error) {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "Enhancement title: %s\n\nEnhancement body:\n%s", title, body)
 
@@ -113,7 +115,7 @@ func SynthesizeResearch(ctx context.Context, provider llm.Provider, title, body 
 		sb.WriteString(joinWithIndex(relatedIssues))
 	}
 
-	raw, err := provider.GenerateJSONWithSystem(ctx, synthesizeResearchSystemPrompt, sb.String(), 0.5, 8192)
+	raw, err := provider.GenerateJSONWithSystem(ctx, synthesizeResearchSystemPrompt(projectName, projectDescription), sb.String(), 0.5, 8192)
 	if err != nil {
 		return nil, fmt.Errorf("synthesize research: %w", err)
 	}

--- a/internal/agent/research_test.go
+++ b/internal/agent/research_test.go
@@ -111,6 +111,7 @@ func TestSynthesizeResearch(t *testing.T) {
 		"Add dark mode", "I want dark mode support",
 		[]string{"Theming guide from docs"},
 		[]string{"Issue #42: Color scheme request"},
+		"", "",
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/codenav/navigate.go
+++ b/internal/codenav/navigate.go
@@ -63,7 +63,7 @@ func New(github *gh.Client, llm llm.Provider, logger *slog.Logger) *Navigator {
 
 // Navigate fetches the repository tree, asks the LLM to identify relevant files,
 // validates the paths, and returns a CodeContext with their contents.
-func (n *Navigator) Navigate(ctx context.Context, installationID int64, repo, title, body string) (CodeContext, error) {
+func (n *Navigator) Navigate(ctx context.Context, installationID int64, repo, title, body, projectName string) (CodeContext, error) {
 	entries, err := n.github.GetTree(ctx, installationID, repo, "main")
 	if err != nil {
 		return CodeContext{}, fmt.Errorf("get tree: %w", err)
@@ -84,7 +84,10 @@ func (n *Navigator) Navigate(ctx context.Context, installationID int64, repo, ti
 		tree = tree[:maxTreePromptSize] + "\n  ... (truncated)\n"
 	}
 
-	systemPrompt := `You are analysing a bug report for a desktop application. Given the bug report and the repository's source file tree, identify the 3-5 most relevant source files that would help diagnose or understand this issue.
+	if projectName == "" {
+		projectName = "a software project"
+	}
+	systemPrompt := fmt.Sprintf(`You are analysing a bug report for %s. Given the bug report and the repository's source file tree, identify the 3-5 most relevant source files that would help diagnose or understand this issue.`, projectName) + `
 
 Focus on files that:
 - Implement the feature or subsystem mentioned in the bug

--- a/internal/comment/builder.go
+++ b/internal/comment/builder.go
@@ -13,7 +13,9 @@ import (
 type TriageResult struct {
 	IsBug         bool
 	IsEnhancement bool
-	IsDocBug      bool // documentation/meta bug — skip PWA note and debug log prompt
+	IsDocBug      bool   // documentation/meta bug — skip PWA note and debug log prompt
+	DocsURL       string // project documentation site URL (empty = omit doc links)
+	DebugCommand  string // shell command for capturing debug logs (empty = omit debug section)
 	Phase1        phases.Phase1Result
 	Phase2        []phases.Suggestion
 	Phase4a       []phases.ContextMatch
@@ -124,12 +126,12 @@ func Build(r TriageResult) string {
 			}
 			parts = append(parts, "")
 		}
-		if !r.IsDocBug && debugMissing {
+		if !r.IsDocBug && debugMissing && r.DebugCommand != "" {
 			parts = append(parts,
 				"<details>\n"+
 					"<summary>How to get debug logs</summary>\n\n"+
 					"```bash\n"+
-					"ELECTRON_ENABLE_LOGGING=true teams-for-linux --logConfig='{\"transports\":{\"console\":{\"level\":\"debug\"}}}'\n"+
+					r.DebugCommand+"\n"+
 					"```\n"+
 					"Reproduce the issue and copy the relevant output.\n\n"+
 					"</details>\n")
@@ -137,52 +139,30 @@ func Build(r TriageResult) string {
 	}
 
 	// Footer: tip + feedback + bot disclosure
-	// Link to relevant docs based on which phases produced output.
-	hasPhase2 := len(r.Phase2) > 0
-	hasPhase4a := len(r.Phase4a) > 0
-	var docLinks string
-	switch {
-	case hasPhase2 && hasPhase4a:
-		docLinks = "[Troubleshooting Guide](https://ismaelmartinez.github.io/teams-for-linux/troubleshooting) " +
-			"| [Roadmap](https://ismaelmartinez.github.io/teams-for-linux/development/plan/roadmap)"
-	case hasPhase2:
-		docLinks = "[Troubleshooting Guide](https://ismaelmartinez.github.io/teams-for-linux/troubleshooting)"
-	case hasPhase4a:
-		docLinks = "[Roadmap](https://ismaelmartinez.github.io/teams-for-linux/development/plan/roadmap)"
-	default:
-		docLinks = "[Project docs](https://ismaelmartinez.github.io/teams-for-linux)"
-	}
-	parts = append(parts,
-		"*Bot suggestion \u2014 "+docLinks+" \u2014 "+
-			"react \U0001F44D/\U0001F44E or [share feedback](https://github.com/IsmaelMartinez/github-issue-triage-bot/issues/new?template=bot-feedback.yml).*")
+	parts = append(parts, buildFooterLine(r))
 
 	return strings.Join(parts, "\n")
 }
 
 // Footer returns the bot disclosure footer line based on which phases produced output.
 func Footer(r TriageResult) string {
-	hasPhase2 := len(r.Phase2) > 0
-	hasPhase4a := len(r.Phase4a) > 0
-	var docLinks string
-	switch {
-	case hasPhase2 && hasPhase4a:
-		docLinks = "[Troubleshooting Guide](https://ismaelmartinez.github.io/teams-for-linux/troubleshooting) " +
-			"| [Roadmap](https://ismaelmartinez.github.io/teams-for-linux/development/plan/roadmap)"
-	case hasPhase2:
-		docLinks = "[Troubleshooting Guide](https://ismaelmartinez.github.io/teams-for-linux/troubleshooting)"
-	case hasPhase4a:
-		docLinks = "[Roadmap](https://ismaelmartinez.github.io/teams-for-linux/development/plan/roadmap)"
-	default:
-		docLinks = "[Project docs](https://ismaelmartinez.github.io/teams-for-linux)"
+	return buildFooterLine(r)
+}
+
+// buildFooterLine generates the footer with a doc link (if DocsURL is set) and feedback link.
+func buildFooterLine(r TriageResult) string {
+	var middle string
+	if r.DocsURL != "" {
+		middle = "[Project docs](" + r.DocsURL + ") \u2014 "
 	}
-	return "*Bot suggestion \u2014 " + docLinks + " \u2014 " +
+	return "*Bot suggestion \u2014 " + middle +
 		"react \U0001F44D/\U0001F44E or [share feedback](https://github.com/IsmaelMartinez/github-issue-triage-bot/issues/new?template=bot-feedback.yml).*"
 }
 
 // DebugInstructions returns the collapsible debug log instructions block,
-// or empty string if debug logs are not missing.
+// or empty string if debug logs are not missing or no debug command is configured.
 func DebugInstructions(r TriageResult) string {
-	if !r.IsBug || r.IsDocBug {
+	if !r.IsBug || r.IsDocBug || r.DebugCommand == "" {
 		return ""
 	}
 	for _, item := range r.Phase1.MissingItems {
@@ -190,7 +170,7 @@ func DebugInstructions(r TriageResult) string {
 			return "<details>\n" +
 				"<summary>How to get debug logs</summary>\n\n" +
 				"```bash\n" +
-				"ELECTRON_ENABLE_LOGGING=true teams-for-linux --logConfig='{\"transports\":{\"console\":{\"level\":\"debug\"}}}'\n" +
+				r.DebugCommand + "\n" +
 				"```\n" +
 				"Reproduce the issue and copy the relevant output.\n\n" +
 				"</details>\n"

--- a/internal/comment/builder_test.go
+++ b/internal/comment/builder_test.go
@@ -17,7 +17,9 @@ func TestBuild_EmptyResult(t *testing.T) {
 
 func TestBuild_BugWithMissingInfo(t *testing.T) {
 	result := TriageResult{
-		IsBug: true,
+		IsBug:        true,
+		DocsURL:      "https://example.com/docs",
+		DebugCommand: "my-app --debug",
 		Phase1: phases.Phase1Result{
 			MissingItems: []phases.MissingItem{
 				{Label: "Reproduction steps", Detail: "Step-by-step instructions"},
@@ -39,6 +41,9 @@ func TestBuild_BugWithMissingInfo(t *testing.T) {
 	if !strings.Contains(got, "How to get debug logs") {
 		t.Error("missing debug instructions")
 	}
+	if !strings.Contains(got, "my-app --debug") {
+		t.Error("debug instructions should contain configured debug command")
+	}
 	if !strings.Contains(got, "Project docs") {
 		t.Error("missing project docs link in footer")
 	}
@@ -47,6 +52,23 @@ func TestBuild_BugWithMissingInfo(t *testing.T) {
 	}
 	if !strings.Contains(got, "share feedback") {
 		t.Error("missing feedback link")
+	}
+}
+
+func TestBuild_BugWithMissingInfoNoDebugCommand(t *testing.T) {
+	result := TriageResult{
+		IsBug: true,
+		Phase1: phases.Phase1Result{
+			MissingItems: []phases.MissingItem{
+				{Label: "Debug console output", Detail: "Log output"},
+				{Label: "Reproduction steps", Detail: "Step-by-step instructions"},
+			},
+		},
+	}
+	got := Build(result)
+
+	if strings.Contains(got, "How to get debug logs") {
+		t.Error("should omit debug instructions when DebugCommand is empty")
 	}
 }
 
@@ -110,6 +132,7 @@ func TestBuild_Phase4aSanitizesNonInfeasibleBranch(t *testing.T) {
 func TestBuild_Enhancement(t *testing.T) {
 	result := TriageResult{
 		IsEnhancement: true,
+		DocsURL:       "https://example.com/docs",
 		Phase4a: []phases.ContextMatch{
 			{Topic: "Dark Mode", Status: "planned", DocURL: "https://example.com/dark", Source: "roadmap", Reason: "appears related"},
 		},
@@ -125,8 +148,8 @@ func TestBuild_Enhancement(t *testing.T) {
 	if !strings.Contains(got, "[Dark Mode](https://example.com/dark)") {
 		t.Error("missing context link")
 	}
-	if !strings.Contains(got, "Roadmap") {
-		t.Error("missing roadmap tip link")
+	if !strings.Contains(got, "Project docs") {
+		t.Error("missing project docs link in footer")
 	}
 }
 
@@ -226,6 +249,7 @@ func TestBuild_UnlabelledIssueWithPhase2(t *testing.T) {
 	result := TriageResult{
 		IsBug:         false,
 		IsEnhancement: false,
+		DocsURL:       "https://example.com/docs",
 		Phase2: []phases.Suggestion{
 			{Title: "Network Timeout", DocURL: "https://example.com/timeout", Reason: "similar network timeout reported"},
 		},
@@ -244,8 +268,8 @@ func TestBuild_UnlabelledIssueWithPhase2(t *testing.T) {
 	if !strings.Contains(got, "[Network Timeout](https://example.com/timeout)") {
 		t.Error("missing suggestion link")
 	}
-	if !strings.Contains(got, "Troubleshooting Guide") {
-		t.Error("missing troubleshooting guide link in footer")
+	if !strings.Contains(got, "Project docs") {
+		t.Error("missing project docs link in footer")
 	}
 	if !strings.Contains(got, "share feedback") {
 		t.Error("missing feedback link")

--- a/internal/config/butler.go
+++ b/internal/config/butler.go
@@ -2,8 +2,19 @@ package config
 
 import "encoding/json"
 
+// ProjectMeta holds per-repo metadata used to parameterize LLM prompts and
+// bot output. Defaults match the teams-for-linux deployment for backward
+// compatibility; other repos override these in their butler.json.
+type ProjectMeta struct {
+	Name         string `json:"name"`          // human-readable project name (e.g. "Teams for Linux")
+	Description  string `json:"description"`   // architecture description for research prompts
+	DocsURL      string `json:"docs_url"`      // base URL for project documentation site
+	DebugCommand string `json:"debug_command"` // shell command users run to capture debug logs
+}
+
 type ButlerConfig struct {
 	Enabled          *bool              `json:"enabled"` // nil treated as true (kill switch)
+	Project          ProjectMeta        `json:"project"`
 	Capabilities     Capabilities       `json:"capabilities"`
 	DocPaths         []string           `json:"doc_paths"`
 	Upstream         []UpstreamDep      `json:"upstream"`
@@ -39,6 +50,19 @@ type SynthesisConfig struct {
 
 func DefaultConfig() ButlerConfig {
 	return ButlerConfig{
+		Project: ProjectMeta{
+			Name: "Teams for Linux",
+			Description: "an Electron desktop wrapper around the Microsoft Teams web app.\n\n" +
+				"Project architecture:\n" +
+				"- Desktop client: Electron + Node.js wrapping the Teams web app in a BrowserWindow\n" +
+				"- Custom CSS injection for theming (user-provided CSS files loaded at startup)\n" +
+				"- Configuration via config.json and CLI flags (Electron flags, proxy, notifications, etc.)\n" +
+				"- System tray integration, notifications, and keyboard shortcuts via Electron APIs\n" +
+				"- Preload scripts for bridging web app and native features\n" +
+				"- The app cannot modify the Teams web UI itself — features must work through Electron APIs, CSS injection, or configuration",
+			DocsURL:      "https://ismaelmartinez.github.io/teams-for-linux",
+			DebugCommand: `ELECTRON_ENABLE_LOGGING=true teams-for-linux --logConfig='{"transports":{"console":{"level":"debug"}}}'`,
+		},
 		Capabilities:     Capabilities{Triage: true, Research: true},
 		DocPaths:         []string{"docs/**", "*.md"},
 		Synthesis:        SynthesisConfig{Frequency: "weekly", Day: "monday"},

--- a/internal/config/butler_test.go
+++ b/internal/config/butler_test.go
@@ -115,3 +115,57 @@ func TestCodeNavigationDefault(t *testing.T) {
 		t.Error("code navigation should be enabled when set")
 	}
 }
+
+func TestProjectMetaDefaults(t *testing.T) {
+	c := DefaultConfig()
+	if c.Project.Name != "Teams for Linux" {
+		t.Errorf("default project name = %q, want %q", c.Project.Name, "Teams for Linux")
+	}
+	if c.Project.DocsURL == "" {
+		t.Error("default DocsURL should not be empty")
+	}
+	if c.Project.DebugCommand == "" {
+		t.Error("default DebugCommand should not be empty")
+	}
+	if c.Project.Description == "" {
+		t.Error("default Description should not be empty")
+	}
+}
+
+func TestProjectMetaParsing(t *testing.T) {
+	input := `{"project":{"name":"My App","docs_url":"https://docs.myapp.io","debug_command":"myapp --debug","description":"a web dashboard"}}`
+	cfg, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if cfg.Project.Name != "My App" {
+		t.Errorf("Name = %q, want %q", cfg.Project.Name, "My App")
+	}
+	if cfg.Project.DocsURL != "https://docs.myapp.io" {
+		t.Errorf("DocsURL = %q, want %q", cfg.Project.DocsURL, "https://docs.myapp.io")
+	}
+	if cfg.Project.DebugCommand != "myapp --debug" {
+		t.Errorf("DebugCommand = %q, want %q", cfg.Project.DebugCommand, "myapp --debug")
+	}
+	if cfg.Project.Description != "a web dashboard" {
+		t.Errorf("Description = %q, want %q", cfg.Project.Description, "a web dashboard")
+	}
+}
+
+func TestProjectMetaEmptyOverride(t *testing.T) {
+	// Explicitly setting empty strings should override defaults
+	input := `{"project":{"name":"","docs_url":"","debug_command":""}}`
+	cfg, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+	if cfg.Project.Name != "" {
+		t.Errorf("Name should be empty when explicitly set, got %q", cfg.Project.Name)
+	}
+	if cfg.Project.DocsURL != "" {
+		t.Errorf("DocsURL should be empty when explicitly set, got %q", cfg.Project.DocsURL)
+	}
+	if cfg.Project.DebugCommand != "" {
+		t.Errorf("DebugCommand should be empty when explicitly set, got %q", cfg.Project.DebugCommand)
+	}
+}

--- a/internal/phases/phase2.go
+++ b/internal/phases/phase2.go
@@ -18,7 +18,7 @@ var reStripCodeFences = regexp.MustCompile("(?s)```[\\s\\S]*?```")
 
 // Phase2 searches for matching troubleshooting documentation using vector similarity
 // and then asks the LLM to pick the best matches with actionable suggestions.
-func Phase2(ctx context.Context, s store.PhaseQuerier, l llm.Provider, logger *slog.Logger, repo, title, body string, codeContext string, preEmbedding []float32) ([]Suggestion, error) {
+func Phase2(ctx context.Context, s store.PhaseQuerier, l llm.Provider, logger *slog.Logger, repo, title, body string, codeContext string, preEmbedding []float32, projectName string) ([]Suggestion, error) {
 	logger.Info("phase2 start")
 	cleanBody := stripCodeFences(body, 1500)
 	queryText := fmt.Sprintf("%s\n%s", truncate(title, 200), cleanBody)
@@ -54,8 +54,11 @@ func Phase2(ctx context.Context, s store.PhaseQuerier, l llm.Provider, logger *s
 		summaries = append(summaries, fmt.Sprintf("[%d] %s (%s): %s", i, d.Title, category, truncate(desc, 200)))
 	}
 
-	systemPrompt := `You are a helpful assistant for the "Teams for Linux" open source project.
-Match this issue against our documentation: troubleshooting guides, configuration options, architecture decisions (ADRs), roadmap items, and research documents.
+	if projectName == "" {
+		projectName = "this"
+	}
+	systemPrompt := fmt.Sprintf(`You are a helpful assistant for the %q open source project.
+Match this issue against our documentation: troubleshooting guides, configuration options, architecture decisions (ADRs), roadmap items, and research documents.`, projectName) + `
 
 Return a JSON array of 0-3 matches. Only include sections with a strong connection (same symptoms, same error message, same component, or a documented decision/limitation that explains the behaviour). For each match, estimate a relevance percentage (60-95). Only include matches above 60%%.
 

--- a/internal/phases/phase2_test.go
+++ b/internal/phases/phase2_test.go
@@ -288,7 +288,7 @@ func TestPhase2(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			results, err := Phase2(context.Background(), tt.store, tt.llm, testLogger(), "test/repo", "Test Issue", "Test body content", "", nil)
+			results, err := Phase2(context.Background(), tt.store, tt.llm, testLogger(), "test/repo", "Test Issue", "Test body content", "", nil, "")
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")

--- a/internal/phases/phase4a.go
+++ b/internal/phases/phase4a.go
@@ -13,7 +13,7 @@ import (
 
 // Phase4a matches enhancement requests against the feature index (roadmap, ADRs, research)
 // using vector similarity search and LLM-based semantic matching.
-func Phase4a(ctx context.Context, s store.PhaseQuerier, l llm.Provider, logger *slog.Logger, repo, title, body string, preEmbedding []float32) ([]ContextMatch, error) {
+func Phase4a(ctx context.Context, s store.PhaseQuerier, l llm.Provider, logger *slog.Logger, repo, title, body string, preEmbedding []float32, projectName string) ([]ContextMatch, error) {
 	logger.Info("phase4a start")
 	cleanBody := stripCodeFences(body, 1500)
 	queryText := fmt.Sprintf("%s\n%s", truncate(title, 200), cleanBody)
@@ -49,8 +49,11 @@ func Phase4a(ctx context.Context, s store.PhaseQuerier, l llm.Provider, logger *
 		summaries = append(summaries, fmt.Sprintf("[%d] (%s) %s: %s", i, status, d.Title, truncate(summary, 120)))
 	}
 
-	systemPrompt := `You are a helpful assistant for the "Teams for Linux" open source project.
-Match this issue against our existing roadmap items, architecture decisions (ADRs), and research documents.
+	if projectName == "" {
+		projectName = "this"
+	}
+	systemPrompt := fmt.Sprintf(`You are a helpful assistant for the %q open source project.
+Match this issue against our existing roadmap items, architecture decisions (ADRs), and research documents.`, projectName) + `
 
 Return a JSON array of 0-3 matches. Only include items with a meaningful connection to the issue (same feature area, overlapping goals, related technical decisions).
 

--- a/internal/phases/phase4a_test.go
+++ b/internal/phases/phase4a_test.go
@@ -211,7 +211,7 @@ func TestPhase4a(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			results, err := Phase4a(context.Background(), tt.store, tt.llm, testLogger(), "test/repo", "Enhancement Request", "Add dark mode support", nil)
+			results, err := Phase4a(context.Background(), tt.store, tt.llm, testLogger(), "test/repo", "Enhancement Request", "Add dark mode support", nil, "")
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -250,7 +250,7 @@ func TestPhase4a_InfeasibleWithRejectedStatus(t *testing.T) {
 		},
 	}
 
-	results, err := Phase4a(context.Background(), storeMock, llmMock, testLogger(), "test/repo", "Title", "Body", nil)
+	results, err := Phase4a(context.Background(), storeMock, llmMock, testLogger(), "test/repo", "Title", "Body", nil, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/phases/synthesis.go
+++ b/internal/phases/synthesis.go
@@ -16,6 +16,7 @@ type SynthesisInput struct {
 	IsBug         bool
 	IsEnhancement bool
 	IsDocBug      bool
+	ProjectName   string
 	Phase1        Phase1Result
 	Phase2        []Suggestion
 	Phase4a       []ContextMatch
@@ -43,7 +44,11 @@ func ShouldSynthesize(input SynthesisInput) bool {
 	return true
 }
 
-const synthesisSystemPrompt = `You are a triage assistant for the "Teams for Linux" open-source project. Write a single, concise GitHub comment responding to a new issue. Write like a knowledgeable maintainer — direct, helpful, no filler.
+func synthesisSystemPrompt(projectName string) string {
+	if projectName == "" {
+		projectName = "this"
+	}
+	return fmt.Sprintf(`You are a triage assistant for the %q open-source project. Write a single, concise GitHub comment responding to a new issue. Write like a knowledgeable maintainer — direct, helpful, no filler.`, projectName) + `
 
 Rules:
 - Keep the response under 1500 characters.
@@ -54,6 +59,7 @@ Rules:
 - If nothing useful was found, return exactly: EMPTY
 
 Return a JSON object with a single field "comment" containing your markdown response (or "EMPTY").`
+}
 
 // Synthesize calls the LLM to produce a single cohesive comment from all phase
 // outputs. Returns empty string if the LLM determines there is nothing useful
@@ -61,7 +67,7 @@ Return a JSON object with a single field "comment" containing your markdown resp
 func Synthesize(ctx context.Context, l llm.Provider, input SynthesisInput) (string, error) {
 	userContent := buildSynthesisPrompt(input)
 
-	raw, err := l.GenerateJSONWithSystem(ctx, synthesisSystemPrompt, userContent, 0.3, 2048)
+	raw, err := l.GenerateJSONWithSystem(ctx, synthesisSystemPrompt(input.ProjectName), userContent, 0.3, 2048)
 	if err != nil {
 		return "", fmt.Errorf("synthesize: %w", err)
 	}

--- a/internal/safety/structural.go
+++ b/internal/safety/structural.go
@@ -47,6 +47,18 @@ func NewStructuralValidator(config StructuralConfig) *StructuralValidator {
 	return v
 }
 
+// AllowHost adds a hostname to the allowed URL hosts set. This is safe to call
+// concurrently — duplicate additions are harmless since the map is append-only.
+func (v *StructuralValidator) AllowHost(host string) {
+	if host == "" {
+		return
+	}
+	if v.allowedHosts == nil {
+		v.allowedHosts = make(map[string]bool)
+	}
+	v.allowedHosts[host] = true
+}
+
 // Validate checks content against all configured structural rules.
 // It returns on the first failure.
 func (v *StructuralValidator) Validate(content string) ValidationResult {

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -570,9 +570,8 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 	// Start agent session for enhancements with shadow repo (requires research capability)
 	if isEnhancement && cfg.Capabilities.Research {
 		if shadowRepo, ok := h.shadowRepos[repo]; ok {
-			h.agentHandler.SetProjectMeta(cfg.Project.Name, cfg.Project.Description)
 			issueLog.Info("starting agent session", "shadowRepo", shadowRepo)
-			if err := h.agentHandler.StartSession(ctx, installationID, repo, issue.Number, shadowRepo, issue.Title, issue.Body); err != nil {
+			if err := h.agentHandler.StartSession(ctx, installationID, repo, issue.Number, shadowRepo, issue.Title, issue.Body, cfg.Project.Name, cfg.Project.Description); err != nil {
 				issueLog.Error("starting agent session", "error", err)
 			}
 		}

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -48,6 +49,7 @@ type Handler struct {
 	wg            sync.WaitGroup
 	ctx           context.Context
 	agentHandler  *agent.AgentHandler
+	structural    *safety.StructuralValidator
 	shadowRepos   map[string]string
 	mirror        *mirror.Service
 	configCaches  map[string]*config.Cache
@@ -87,6 +89,7 @@ func New(webhookSecret string, sourceRepo string, s *store.Store, l llm.Provider
 		logger:        logger,
 		ctx:           ctx,
 		agentHandler:  agentHandler,
+		structural:    structural,
 		shadowRepos:   shadowRepos,
 		mirror:        mirrorSvc,
 		configCaches:  make(map[string]*config.Cache),
@@ -356,6 +359,14 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 	if !cfg.IsEnabled() {
 		issueLog.Info("bot is disabled via butler.json, skipping")
 		return
+	}
+
+	// Register the project's docs URL host with the safety validator so
+	// LLM-generated links to project documentation are not rejected.
+	if cfg.Project.DocsURL != "" {
+		if u, err := url.Parse(cfg.Project.DocsURL); err == nil && u.Hostname() != "" {
+			h.structural.AllowHost(u.Hostname())
+		}
 	}
 
 	// Set LLM daily limit from config

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -409,6 +409,8 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 	result.IsBug = isBug
 	result.IsEnhancement = isEnhancement
 	result.IsDocBug = isBug && isDocumentationBug(issue.Title)
+	result.DocsURL = cfg.Project.DocsURL
+	result.DebugCommand = cfg.Project.DebugCommand
 	var phaseErrors []string // track LLM phase errors for shadow-mode fallback
 	var embedding []float32
 
@@ -434,7 +436,7 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 	// Code navigation: fetch relevant source files for Phase 2 context (bugs only)
 	var codeCtx string
 	if isBug && cfg.Capabilities.Triage && cfg.Capabilities.CodeNavigation {
-		cc, err := h.codeNav.Navigate(ctx, installationID, dataRepo, issue.Title, issue.Body)
+		cc, err := h.codeNav.Navigate(ctx, installationID, dataRepo, issue.Title, issue.Body, cfg.Project.Name)
 		if err != nil {
 			issueLog.Error("code navigation failed", "error", err)
 		} else {
@@ -444,7 +446,7 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 
 	// Phase 2: Solution suggestions
 	if cfg.Capabilities.Triage {
-		p2, err := phases.Phase2(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body, codeCtx, embedding)
+		p2, err := phases.Phase2(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body, codeCtx, embedding, cfg.Project.Name)
 		if err != nil {
 			issueLog.Error("phase 2 failed", "error", err)
 			phaseErrors = append(phaseErrors, fmt.Sprintf("Phase 2: %s", err.Error()))
@@ -455,7 +457,7 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 
 	// Phase 4a: Enhancement context
 	if cfg.Capabilities.Triage {
-		p4a, err := phases.Phase4a(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body, embedding)
+		p4a, err := phases.Phase4a(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body, embedding, cfg.Project.Name)
 		if err != nil {
 			issueLog.Error("phase 4a failed", "error", err)
 			phaseErrors = append(phaseErrors, fmt.Sprintf("Phase 4a: %s", err.Error()))
@@ -471,6 +473,7 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 		IsBug:         isBug,
 		IsEnhancement: isEnhancement,
 		IsDocBug:      result.IsDocBug,
+		ProjectName:   cfg.Project.Name,
 		Phase1:        result.Phase1,
 		Phase2:        result.Phase2,
 		Phase4a:       result.Phase4a,
@@ -567,6 +570,7 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 	// Start agent session for enhancements with shadow repo (requires research capability)
 	if isEnhancement && cfg.Capabilities.Research {
 		if shadowRepo, ok := h.shadowRepos[repo]; ok {
+			h.agentHandler.SetProjectMeta(cfg.Project.Name, cfg.Project.Description)
 			issueLog.Info("starting agent session", "shadowRepo", shadowRepo)
 			if err := h.agentHandler.StartSession(ctx, installationID, repo, issue.Number, shadowRepo, issue.Title, issue.Body); err != nil {
 				issueLog.Error("starting agent session", "error", err)
@@ -588,6 +592,8 @@ func (h *Handler) handleRetriage(ctx context.Context, installationID int64, repo
 		dataRepo = h.sourceRepo
 	}
 
+	cfg := h.getConfig(ctx, installationID, repo)
+
 	isBug := hasLabel(issue.Labels, "bug")
 	isEnhancement := hasLabel(issue.Labels, "enhancement")
 
@@ -595,6 +601,8 @@ func (h *Handler) handleRetriage(ctx context.Context, installationID int64, repo
 	result.IsBug = isBug
 	result.IsEnhancement = isEnhancement
 	result.IsDocBug = isBug && isDocumentationBug(issue.Title)
+	result.DocsURL = cfg.Project.DocsURL
+	result.DebugCommand = cfg.Project.DebugCommand
 	var phaseErrors []string
 
 	result.Phase1 = phases.Phase1(issue.Body)
@@ -608,14 +616,14 @@ func (h *Handler) handleRetriage(ctx context.Context, installationID int64, repo
 		embedding = nil
 	}
 
-	p2, err := phases.Phase2(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body, "", embedding)
+	p2, err := phases.Phase2(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body, "", embedding, cfg.Project.Name)
 	if err != nil {
 		issueLog.Error("retriage phase 2 failed", "error", err)
 		phaseErrors = append(phaseErrors, fmt.Sprintf("Phase 2: %s", err.Error()))
 	}
 	result.Phase2 = p2
 
-	p4a, err := phases.Phase4a(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body, embedding)
+	p4a, err := phases.Phase4a(ctx, h.store, h.llm, issueLog, dataRepo, issue.Title, issue.Body, embedding, cfg.Project.Name)
 	if err != nil {
 		issueLog.Error("retriage phase 4a failed", "error", err)
 		phaseErrors = append(phaseErrors, fmt.Sprintf("Phase 4a: %s", err.Error()))
@@ -629,6 +637,7 @@ func (h *Handler) handleRetriage(ctx context.Context, installationID int64, repo
 		IsBug:         isBug,
 		IsEnhancement: isEnhancement,
 		IsDocBug:      result.IsDocBug,
+		ProjectName:   cfg.Project.Name,
 		Phase1:        result.Phase1,
 		Phase2:        result.Phase2,
 		Phase4a:       result.Phase4a,


### PR DESCRIPTION
All hardcoded "Teams for Linux" references in LLM system prompts, debug
commands, and documentation links are now configurable per-repo through the
butler.json `project` field. Defaults match the current teams-for-linux
deployment for backward compatibility. This enables multi-repo support
without producing incorrect or misleading bot output.

Changes:
- Add ProjectMeta struct (name, description, docs_url, debug_command) to
  ButlerConfig with teams-for-linux defaults
- Thread project name through Phase 2, Phase 4a, and Synthesis system prompts
- Thread project description through research agent prompts
- Thread project name through code navigator prompts
- Make comment builder debug instructions and footer doc links configurable
  via DocsURL and DebugCommand on TriageResult
- Update webhook handler (triage + retriage paths) to pass config values
- Update backfill command for new Phase2/Phase4a signatures
- Add AgentHandler.SetProjectMeta() for research prompt configuration
- Update all affected tests

https://claude.ai/code/session_017r3yZmcCizBETfYpY35Kfd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-repository project metadata configuration (name, description, documentation URL, debug command) via `butler.json` configuration files.
  * LLM system prompts and bot-generated output (documentation links, debug logging instructions) now dynamically adapt to project-specific settings instead of hard-coded defaults, enabling customization across different projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->