### PR TITLE
docs: align CLAUDE.md, README, CONTRIBUTING with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ gh workflow run seed.yml -f seed_type=features -f data_file=data/feature-index.j
 
 The service receives GitHub webhook events (issue opened/closed/reopened, issue comments, issue edits) and runs a focused triage pipeline. Phase 3 (duplicate detection) and Phase 4b (misclassification) were removed in favour of GitHub native tooling — see `docs/plans/2026-03-15-lean-bot-pivot-design.md`.
 
-Phase 1 (pure parsing, no LLM): detects missing information in bug reports by checking form sections against known templates. Phase 2 (pgvector + LLM): embeds the issue, searches all document types (troubleshooting, configuration, ADR, roadmap, research) for similar entries with per-category relevance thresholds (troubleshooting 70%, ADR/roadmap/research 55%, configuration 50%), sends top-5 to Gemini to generate suggestions. Phase 4a (pgvector + LLM): searches roadmap/ADR/research documents for related context. All phases run for every issue regardless of labels; a single embedding is computed once and shared across Phase 2 and Phase 4a.
+Phase 1 (pure parsing, no LLM): detects missing information in bug reports by checking form sections against known templates. Phase 2 (pgvector + LLM): embeds the issue, searches all document types (troubleshooting, configuration, ADR, roadmap, research) for similar entries with per-category relevance thresholds (troubleshooting 70%, ADR/roadmap/research 55%, configuration 50%), sends top-5 to Gemini to generate suggestions. Phase 4a (pgvector + LLM): searches roadmap/ADR/research documents for related context. All phases run for every issue regardless of labels; a single embedding is computed once and shared across Phase 2 and Phase 4a. Phase identifiers stored in the database use friendly names (`missing_info`, `doc_search`, `enhancement_context`, `synthesis`) — see `migrations/013_rename_phases.sql`; the Go source files still use the historic `phase1.go` / `phase2.go` / `phase4a.go` naming.
 
 A synthesis step (`internal/phases/synthesis.go`) takes all phase outputs and produces one coherent response via an LLM call, weaving doc matches with missing-info requests (e.g., "this looks like [doc X], debug logs would help confirm"). The `ShouldSynthesize` guard skips the LLM call for trivially simple cases (single missing item, no doc matches). On synthesis failure, the comment builder (`internal/comment/builder.go`) produces a fallback concatenated response. Debug log instructions and the feedback footer are appended deterministically after synthesis. When a shadow repo is configured, the triage comment is posted there for maintainer review; on `lgtm`, a curated summary is promoted to the original public issue. The bot also tracks feedback signals: when users edit their issue to fill in Phase 1 flagged sections (via `issues.edited` webhook), and when users @mention the bot. A `/health-check` endpoint monitors confidence score trends, stuck sessions, and orphaned triage, creating GitHub alert issues when thresholds are violated.
 
@@ -78,7 +78,7 @@ For enhancement issues with a configured shadow repo, the bot also starts an age
 ## Project Structure
 
 ```
-cmd/server/main.go           # HTTP server entry point (/webhook, /health, /health-check, /ingest, /synthesize, /report, /report/trends, /dashboard)
+cmd/server/main.go           # HTTP server entry point (/webhook, /health, /cleanup, /health-check, /ingest, /pause, /unpause, /synthesize, /dashboard, /report, /report/trends, /api/triage/, /api/agent/)
 cmd/server/dashboard.go       # Live dashboard handler (go:embed template, /dashboard endpoint)
 cmd/server/template.html      # Dashboard template (sidebar layout, Chart.js charts, drill-down)
 cmd/seed/main.go              # CLI to import JSON indexes into database
@@ -100,6 +100,7 @@ internal/store/feedback.go    # Feedback signal storage and stats
 internal/store/models.go      # Shared data types (includes agent stage/gate constants)
 internal/store/events.go      # Event journal (repo_events) queries
 internal/store/references.go  # Cross-reference index (doc_references) queries
+internal/codenav/             # Code navigation: fetches relevant source files to augment Phase 2 prompts (opt-in via butler.json code_navigation capability)
 internal/agent/handler.go     # Agent handler: context brief (default) and research flows
 internal/agent/orchestrator.go # Approval signal parsing (lgtm, revise, reject, publish)
 internal/agent/research.go    # Enhancement analysis and research synthesis prompts
@@ -123,14 +124,15 @@ scripts/generate-upstream-index.sh # Generate seed JSON from upstream dependency
 data/                         # Seed data (feature index, Electron upstream docs)
 internal/webhook/journal.go   # Event journal writes from webhook events
 internal/webhook/autoingest.go # Auto-ingest changed docs on push
-migrations/                   # Database migrations (001-012)
+migrations/                   # Database migrations (001-014; 005 was superseded in-flight and skipped)
 terraform/main.tf             # GCP infrastructure (Cloud Run, AR, budget, secrets)
 .github/workflows/deploy.yml  # CI/CD: test on PR, build+deploy on push to main
 .github/workflows/dashboard.yml # Daily maintenance: stale cleanup, health check, reaction sync
 .github/workflows/seed.yml    # Manual seed workflow (workflow_dispatch)
 .github/workflows/event-ingest.yml # Daily event ingestion from GitHub API
 .github/workflows/synthesis.yml    # Weekly synthesis briefing cron (Monday 06:00 UTC)
-docs/decisions/               # Architecture decision records
+docs/adr/                     # Architecture decision records (technical choices: provider, infra, security)
+docs/decisions/               # Project decision records (design pivots, strategic changes)
 docs/plans/                   # Implementation plans and design docs
 .golangci.yml                 # Linter configuration
 CONTRIBUTING.md               # Developer setup and contribution guidelines
@@ -165,7 +167,7 @@ Phase 1 is pure string parsing (no network calls) and has the most comprehensive
 
 The comment builder produces concise output: a single-sentence preamble, no greeting line, a compact footer with a feedback hint. Keep builder output minimal. All LLM prompts and bot output (debug command, doc links, project name) are parameterized via `config.ProjectMeta` in the per-repo butler.json `project` field. Defaults match the teams-for-linux deployment.
 
-Environment variables: DATABASE_URL (required), GEMINI_API_KEY (optional, warns if missing), GITHUB_APP_ID (required, numeric App ID), GITHUB_PRIVATE_KEY (required, base64-encoded or raw PEM), WEBHOOK_SECRET (required), SOURCE_REPO (optional, overrides repo for vector searches), SHADOW_REPOS (optional, comma-separated "owner/repo:owner/shadow" mappings for agent sessions), INGEST_SECRET (optional, authenticates /ingest and /synthesize endpoints; empty disables auth), PORT (optional, defaults to 8080). The cmd/sync-reactions tool uses REPO (optional, defaults to IsmaelMartinez/teams-for-linux) to select which repository's comments to sync.
+Environment variables: DATABASE_URL (required), GEMINI_API_KEY (optional, warns if missing), GITHUB_APP_ID (required, numeric App ID), GITHUB_PRIVATE_KEY (required, base64-encoded or raw PEM), WEBHOOK_SECRET (required), SOURCE_REPO (optional, overrides repo for vector searches), SHADOW_REPOS (optional, comma-separated "owner/repo:owner/shadow" mappings for agent sessions), INGEST_SECRET (optional, authenticates /cleanup, /health-check, /ingest, /synthesize, /pause, /unpause; empty disables auth), MAX_DAILY_LLM_CALLS (optional integer, overrides the default Gemini call budget), MIRROR_CACHE_DIR (optional, directory for the shadow-repo mirror service; defaults to os.TempDir()), PORT (optional, defaults to 8080). The cmd/sync-reactions tool uses REPO (optional, defaults to IsmaelMartinez/teams-for-linux) to select which repository's comments to sync.
 
 ## Issue Template Headers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,7 @@ export GEMINI_API_KEY="..."
 export GITHUB_APP_ID="..."
 export GITHUB_PRIVATE_KEY="..."   # base64-encoded PEM
 export WEBHOOK_SECRET="..."
-export SILENT_MODE="false"          # optional, default "true" (observer mode)
-export SHADOW_REPOS="owner/repo:owner/shadow"  # optional, comma-separated mappings
+export SHADOW_REPOS="owner/repo:owner/shadow"  # optional, comma-separated mappings; without it nothing is posted publicly
 ```
 
 Build and run:

--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ Cloud Run (Go binary)
         |       +-- Missing info check: template parsing (no LLM)
         |       +-- Known solutions: pgvector search + Gemini (bugs)
         |       +-- Related context: pgvector search + Gemini (enhancements)
+        |       +-- Synthesis: weave phase outputs into a single coherent comment (Gemini)
         |       |
         |       v
-        |   Post comment / store for dashboard (silent mode)
+        |   Post to shadow repo for maintainer review (lgtm to promote to public issue)
         |
         +-- Enhancement Researcher Agent (if shadow repo configured)
         |       +-- Create mirror issue in shadow repo
@@ -90,15 +91,15 @@ Neon PostgreSQL + pgvector             GitHub Pages Dashboard
  agent_sessions, feedback_signals)
 ```
 
-### Silent mode
+### Shadow-repo review gate
 
-The bot defaults to silent (observer) mode, controlled by the `SILENT_MODE` environment variable (default: `"true"`). In silent mode, triage results are stored in the database for dashboard review but no comments are posted on GitHub issues. Set `SILENT_MODE=false` to enable public commenting. Agent sessions in shadow repos are unaffected by this setting. See `docs/decisions/002-silent-mode.md` for the full rationale.
+Every triage comment and agent session is first mirrored into a private shadow repository configured via `SHADOW_REPOS`. Maintainers review the draft there and reply with `lgtm` to promote a curated summary to the public issue, or `reject` to discard. Nothing reaches public issues without explicit approval. This pattern replaced the original silent-mode observer design (see `docs/decisions/003-shadow-repo-pattern.md`, which supersedes `docs/decisions/002-silent-mode.md`).
 
 ### Environment variables
 
 The server requires `DATABASE_URL`, `GITHUB_APP_ID`, `GITHUB_PRIVATE_KEY`, and `WEBHOOK_SECRET`. `GEMINI_API_KEY` is optional (the bot logs a warning and skips LLM phases if unset). `GITHUB_PRIVATE_KEY` should contain the PEM content either as raw PEM text or base64-encoded PEM.
 
-Optional variables controlling runtime behavior: `SOURCE_REPO` overrides the repository used for vector similarity searches (useful when testing against a different repo than the one sending webhooks). `SILENT_MODE` (default `"true"`) controls whether triage comments are posted publicly or stored silently for dashboard review — set to `"false"` to enable posting. `SHADOW_REPOS` defines shadow repo mappings for the Enhancement Researcher agent as comma-separated `owner/repo:owner/shadow` pairs (e.g., `IsmaelMartinez/teams-for-linux:IsmaelMartinez/triage-bot-shadow`). `PORT` sets the HTTP listen port (defaults to 8080).
+Optional variables controlling runtime behavior: `SOURCE_REPO` overrides the repository used for vector similarity searches (useful when testing against a different repo than the one sending webhooks). `SHADOW_REPOS` defines shadow repo mappings as comma-separated `owner/repo:owner/shadow` pairs (e.g., `IsmaelMartinez/teams-for-linux:IsmaelMartinez/triage-bot-shadow`); without it, the bot skips mirroring and posts nothing publicly. `INGEST_SECRET` authenticates the `/cleanup`, `/health-check`, `/ingest`, `/synthesize`, `/pause`, and `/unpause` endpoints (empty disables auth). `MAX_DAILY_LLM_CALLS` overrides the default daily Gemini budget. `MIRROR_CACHE_DIR` sets the shadow-repo mirror cache (defaults to the system temp dir). `PORT` sets the HTTP listen port (defaults to 8080).
 
 ### Deployment
 

--- a/docs/decisions/002-silent-mode.md
+++ b/docs/decisions/002-silent-mode.md
@@ -1,7 +1,9 @@
 # Silent Mode — Observe Before Acting
 
 Date: 2026-03-04
-Status: Accepted
+Status: Superseded by [ADR-003](003-shadow-repo-pattern.md) (2026-03-05)
+
+> **Note (2026-04-14):** The `SILENT_MODE` environment variable and the `triage_results` draft-comment table were removed when the shadow-repo review gate landed (migration `008_drop_triage_results.sql`). All triage and agent output now flows through a shadow repository instead. This record is retained for historical context only.
 
 ## Context
 


### PR DESCRIPTION
Repository review found several places where the docs had drifted from the
implementation:

- CLAUDE.md listed migrations as 001-012 (now 001-014), missed internal/codenav/
  and docs/adr/ in the project structure, omitted /cleanup, /pause, /unpause,
  /api/triage/, /api/agent/ from the server endpoint summary, and didn't
  document MAX_DAILY_LLM_CALLS or MIRROR_CACHE_DIR. INGEST_SECRET was listed
  as protecting only /ingest and /synthesize, but also protects /cleanup,
  /health-check, /pause, and /unpause.
- CLAUDE.md's phase description didn't mention the rename in migration 013
  (phase1 -> missing_info, phase2 -> doc_search, phase4a -> enhancement_context).
- README.md still described SILENT_MODE as the primary posting gate, but that
  env var was removed along with the triage_results table (migration 008) when
  the shadow-repo review gate replaced it. Updated the architecture diagram and
  runtime-variable section to describe the current shadow-repo flow.
- CONTRIBUTING.md exported SILENT_MODE in its local-setup example; removed.
- docs/decisions/002-silent-mode.md marked Accepted but was superseded by
  ADR-003 in March 2026. Status updated with a banner noting the removal.

No code changes; tests and vet pass.