### PR TITLE
chore: surface underlying error in /cleanup response

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -155,7 +155,7 @@ func main() {
 		stale, err := s.ListStaleSessions(r.Context(), staleDuration)
 		if err != nil {
 			logger.Error("failed to list stale sessions", "error", err)
-			http.Error(w, "failed to list stale sessions", http.StatusInternalServerError)
+			http.Error(w, fmt.Sprintf("failed to list stale sessions: %v", err), http.StatusInternalServerError)
 			return
 		}
 


### PR DESCRIPTION
Tiny debug-aid change. PR #114 fixed the NULL scan error but /cleanup still returns HTTP 500 with body `failed to list stale sessions` — the underlying error is only in Cloud Run logs, which I can't read from this environment. Include it in the HTTP body so we can see what's actually failing.