### PR TITLE
chore: auto-merge dependabot PRs and group minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "deps"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: github-actions
     directory: /
@@ -17,3 +22,8 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "ci"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge on non-major updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary
- Adds the `dependabot-auto-merge.yml` workflow used across the portfolio: auto-enables merge on Dependabot PRs whose update-type is not `semver-major`. Major bumps remain manual.
- Updates `.github/dependabot.yml` to add `groups.minor-and-patch` so minor/patch updates land as a single weekly PR per ecosystem (otherwise the queue would clutter quickly with one PR per package).
- Pairs with `allow_auto_merge: true` at the repo level.

## Test plan
- [ ] Next dependabot minor/patch PR groups its updates and auto-merges on green
- [ ] A major bump still arrives as its own PR and does NOT auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)