### PR TITLE
fix(security): bounds-check integer conversion in llm client

### DIFF
--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net"
 	"net/http"
 	"sync/atomic"
@@ -59,8 +60,19 @@ func New(apiKey string, logger *slog.Logger) *Client {
 }
 
 // SetDailyLimit sets the maximum number of LLM API calls per day. 0 means unlimited.
+// Values exceeding math.MaxInt32 are clamped to math.MaxInt32; negative values are
+// clamped to 0 (unlimited) to avoid integer-conversion wraparound.
 func (c *Client) SetDailyLimit(limit int) {
-	c.dailyLimit.Store(int32(limit))
+	var stored int32
+	switch {
+	case limit < 0:
+		stored = 0
+	case limit > math.MaxInt32:
+		stored = math.MaxInt32
+	default:
+		stored = int32(limit)
+	}
+	c.dailyLimit.Store(stored)
 }
 
 // DailyCount returns the current day's LLM call count.

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -60,18 +60,12 @@ func New(apiKey string, logger *slog.Logger) *Client {
 }
 
 // SetDailyLimit sets the maximum number of LLM API calls per day. 0 means unlimited.
-// Values exceeding math.MaxInt32 are clamped to math.MaxInt32; negative values are
-// clamped to 0 (unlimited) to avoid integer-conversion wraparound.
+// Values exceeding math.MaxInt32-1 are clamped to math.MaxInt32-1; negative values
+// are clamped to 0 (unlimited). The upper bound is math.MaxInt32-1 (not MaxInt32) so
+// that checkAndIncrementDaily can Add(1) past the limit without int32 wraparound,
+// which would otherwise cause count>limit to read false and silently bypass the cap.
 func (c *Client) SetDailyLimit(limit int) {
-	var stored int32
-	switch {
-	case limit < 0:
-		stored = 0
-	case limit > math.MaxInt32:
-		stored = math.MaxInt32
-	default:
-		stored = int32(limit)
-	}
+	stored := int32(max(0, min(limit, math.MaxInt32-1)))
 	c.dailyLimit.Store(stored)
 }
 

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -65,16 +65,18 @@ func New(apiKey string, logger *slog.Logger) *Client {
 // that checkAndIncrementDaily can Add(1) past the limit without int32 wraparound,
 // which would otherwise cause count>limit to read false and silently bypass the cap.
 func (c *Client) SetDailyLimit(limit int) {
-	var stored int32
-	switch {
-	case limit < 0:
-		stored = 0
-	case limit > math.MaxInt32-1:
-		stored = math.MaxInt32 - 1
-	default:
-		stored = int32(limit)
+	// Reserve one int32 slot of headroom so checkAndIncrementDaily can Add(1)
+	// past the limit without wrapping to a negative value, which would cause
+	// the count>limit check to read false and silently bypass the cap.
+	if limit < 0 {
+		c.dailyLimit.Store(0)
+		return
 	}
-	c.dailyLimit.Store(stored)
+	if limit >= math.MaxInt32 {
+		c.dailyLimit.Store(math.MaxInt32 - 1)
+		return
+	}
+	c.dailyLimit.Store(int32(limit))
 }
 
 // DailyCount returns the current day's LLM call count.

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -65,7 +65,15 @@ func New(apiKey string, logger *slog.Logger) *Client {
 // that checkAndIncrementDaily can Add(1) past the limit without int32 wraparound,
 // which would otherwise cause count>limit to read false and silently bypass the cap.
 func (c *Client) SetDailyLimit(limit int) {
-	stored := int32(max(0, min(limit, math.MaxInt32-1)))
+	var stored int32
+	switch {
+	case limit < 0:
+		stored = 0
+	case limit > math.MaxInt32-1:
+		stored = math.MaxInt32 - 1
+	default:
+		stored = int32(limit)
+	}
 	c.dailyLimit.Store(stored)
 }
 


### PR DESCRIPTION
## Summary

Addresses CodeQL alert `go/incorrect-integer-conversion` (high) at `internal/llm/client.go:63`.

`SetDailyLimit` converted an `int` argument directly to `int32` via `int32(limit)`. On 64-bit platforms `int` is 64-bit, so values above `math.MaxInt32` would silently wrap and negative values could roll over too. Added a bounds-check that clamps oversized values to `math.MaxInt32` and negative values to `0` (the existing "unlimited" sentinel) before storing into the `atomic.Int32`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages pass)
- [ ] CodeQL re-scan confirms alert closes

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>