### PR TITLE
docs(roadmap): track Electron 40/41 seeding and bare #NNN autolink leak

### DIFF
--- a/docs/plans/2026-03-04-roadmap.md
+++ b/docs/plans/2026-03-04-roadmap.md
@@ -306,6 +306,8 @@ Open issues for future consideration:
 - ~~Deepen repo-butler integration~~ Both MCP servers shipped, integration is live
 - Q4 (retrospective compliance audit) — when 50+ sessions accumulate, write an agent.
 - Evaluate `actions/ai-inference` + GitHub AI labeler as a zero-infrastructure alternative for issue labelling.
+- Seed Electron 40 and 41 upstream docs (releases + issues) into the vector store. v39 is two majors stale now that teams-for-linux ships 41.2.2; the trigger noted in `docs/plans/2026-03-16-upstream-dependency-docs.md` (Electron 40 migration) has been overshot. Drop v39 once 42 lands. A monthly refresh GitHub Action would compound. Drafted prompt at `~/projects/github/triage-bot-test-repo/triage-bot-improvements-prompt.md` covers the steps.
+- Stop bare `#NNN` references in synthesised prose from auto-linking against the consumer repo (teams-for-linux) when the actual reference is upstream (electron/electron). Two-step fix: tighten the synthesis prompt, then add a deterministic rewrite in `internal/comment/sanitize.go` keyed off the `doc_url` of each upstream-doc reference sent into the prompt. Same prompt file covers it.
 
 ## What We're Not Doing
 

--- a/docs/plans/2026-03-04-roadmap.md
+++ b/docs/plans/2026-03-04-roadmap.md
@@ -306,8 +306,8 @@ Open issues for future consideration:
 - ~~Deepen repo-butler integration~~ Both MCP servers shipped, integration is live
 - Q4 (retrospective compliance audit) — when 50+ sessions accumulate, write an agent.
 - Evaluate `actions/ai-inference` + GitHub AI labeler as a zero-infrastructure alternative for issue labelling.
-- Seed Electron 40 and 41 upstream docs (releases + issues) into the vector store. v39 is two majors stale now that teams-for-linux ships 41.2.2; the trigger noted in `docs/plans/2026-03-16-upstream-dependency-docs.md` (Electron 40 migration) has been overshot. Drop v39 once 42 lands. A monthly refresh GitHub Action would compound. Drafted prompt at `~/projects/github/triage-bot-test-repo/triage-bot-improvements-prompt.md` covers the steps.
-- Stop bare `#NNN` references in synthesised prose from auto-linking against the consumer repo (teams-for-linux) when the actual reference is upstream (electron/electron). Two-step fix: tighten the synthesis prompt, then add a deterministic rewrite in `internal/comment/sanitize.go` keyed off the `doc_url` of each upstream-doc reference sent into the prompt. Same prompt file covers it.
+- Seed Electron 40 and 41 upstream docs (releases + issues) into the vector store. v39 is two majors stale now that teams-for-linux ships 41.2.2; the trigger noted in `docs/plans/2026-03-16-upstream-dependency-docs.md` (Electron 40 migration) has been overshot. Drop v39 once 42 lands. A monthly refresh GitHub Action would compound.
+- Stop bare `#NNN` references in synthesised prose from auto-linking against the consumer repo (teams-for-linux) when the actual reference is upstream (electron/electron). Two-step fix: tighten the synthesis prompt, then add a deterministic rewrite in `internal/comment/sanitize.go` keyed off the `doc_url` of each upstream-doc reference sent into the prompt.
 
 ## What We're Not Doing
 

--- a/docs/plans/2026-03-04-roadmap.md
+++ b/docs/plans/2026-03-04-roadmap.md
@@ -306,8 +306,8 @@ Open issues for future consideration:
 - ~~Deepen repo-butler integration~~ Both MCP servers shipped, integration is live
 - Q4 (retrospective compliance audit) — when 50+ sessions accumulate, write an agent.
 - Evaluate `actions/ai-inference` + GitHub AI labeler as a zero-infrastructure alternative for issue labelling.
-- Seed Electron 40 and 41 upstream docs (releases + issues) into the vector store. v39 is two majors stale now that teams-for-linux ships 41.2.2; the trigger noted in `docs/plans/2026-03-16-upstream-dependency-docs.md` (Electron 40 migration) has been overshot. Drop v39 once 42 lands. A monthly refresh GitHub Action would compound.
-- Stop bare `#NNN` references in synthesised prose from auto-linking against the consumer repo (teams-for-linux) when the actual reference is upstream (electron/electron). Two-step fix: tighten the synthesis prompt, then add a deterministic rewrite in `internal/comment/sanitize.go` keyed off the `doc_url` of each upstream-doc reference sent into the prompt.
+- ~~Seed Electron 40 and 41 upstream docs~~ DONE (PR #135, 2026-05-03). v40 and v41 (releases + issues) seeded; v39 retained until v42 lands. The seed script now truncates summaries at the last newline boundary to avoid broken markdown links. A monthly refresh GitHub Action remains a worthwhile follow-up.
+- ~~Stop bare `#NNN` references from auto-linking against the consumer repo when the actual reference is upstream~~ DONE (PR #136, 2026-05-03). Two-step fix shipped: synthesis prompt tightened, and `RewriteBareUpstreamRefs` in `internal/comment/sanitize.go` rewrites bare `#NNN` matches against the upstream doc URLs sent into the prompt while preserving local refs, code spans, and existing markdown links.
 
 ## What We're Not Doing
 


### PR DESCRIPTION
## Summary
- Append two open items to `docs/plans/2026-03-04-roadmap.md` under "Open issues for future consideration".
- Both surfaced from the 2026-05-03 teams-for-linux issue-review session: seed Electron v40/v41 upstream docs (v39 is two majors stale) and stop bare `#NNN` references from auto-linking against teams-for-linux when the underlying reference is upstream.
- Implementation PRs for the two items are following separately.

## Test plan
- [ ] Roadmap renders correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)