### PR TITLE
fix(comment): rewrite bare #NNN upstream refs to qualified form

### DIFF
--- a/internal/comment/sanitize.go
+++ b/internal/comment/sanitize.go
@@ -2,6 +2,7 @@ package comment
 
 import (
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -13,7 +14,19 @@ var (
 	scriptTagRe       = regexp.MustCompile(`(?is)<script[^>]*>.*?</script>`)
 	htmlTagRe         = regexp.MustCompile(`<[^>]*>`)
 	dangerousSchemeRe = regexp.MustCompile(`(?i)^(javascript|data|vbscript):`)
+
+	// upstreamURLRe matches GitHub issue/PR URLs and captures owner, repo, and number.
+	upstreamURLRe = regexp.MustCompile(`^https?://github\.com/([^/]+)/([^/]+)/(?:issues|pull)/(\d+)`)
 )
+
+// UpstreamRef identifies an upstream GitHub repository issue/PR reference parsed
+// from a doc_url. It is used by rewriteBareUpstreamRefs to qualify bare `#NNN`
+// references in synthesised prose.
+type UpstreamRef struct {
+	Owner  string
+	Repo   string
+	Number int
+}
 
 // SanitizeLLMOutput strips images, dangerous links, script tags, and HTML from LLM text.
 func SanitizeLLMOutput(s string) string {
@@ -36,4 +49,184 @@ func sanitizeURL(u string) string {
 		return ""
 	}
 	return trimmed
+}
+
+// ExtractUpstreamRefs parses GitHub issue/PR URLs out of the given doc URLs and
+// returns the matching UpstreamRef set. URLs that do not point to a GitHub
+// issue or pull request are skipped.
+func ExtractUpstreamRefs(docURLs []string) []UpstreamRef {
+	var refs []UpstreamRef
+	for _, u := range docURLs {
+		m := upstreamURLRe.FindStringSubmatch(strings.TrimSpace(u))
+		if m == nil {
+			continue
+		}
+		n, err := strconv.Atoi(m[3])
+		if err != nil {
+			continue
+		}
+		refs = append(refs, UpstreamRef{Owner: m[1], Repo: m[2], Number: n})
+	}
+	return refs
+}
+
+// RewriteBareUpstreamRefs rewrites bare `#NNN` references in text to the
+// qualified `OWNER/REPO#NNN` form when the number matches an upstream
+// reference. It does NOT touch numbers inside markdown link text/URLs,
+// already-qualified `owner/repo#NNN` refs, or full URLs. When a number
+// appears in localIssueHints, the rewrite is skipped (local takes precedence
+// over upstream — bare `#NNN` in maintainer prose conventionally means the
+// host repo). The rewrite is idempotent.
+func RewriteBareUpstreamRefs(text string, upstreamRefs []UpstreamRef, localIssueHints map[int]bool) string {
+	return rewriteBareUpstreamRefs(text, upstreamRefs, localIssueHints)
+}
+
+func rewriteBareUpstreamRefs(text string, upstreamRefs []UpstreamRef, localIssueHints map[int]bool) string {
+	if len(upstreamRefs) == 0 {
+		return text
+	}
+
+	// Index upstream refs by number. If two upstream refs share the same
+	// number (unlikely in practice), the first wins.
+	byNumber := make(map[int]UpstreamRef, len(upstreamRefs))
+	for _, r := range upstreamRefs {
+		if _, exists := byNumber[r.Number]; !exists {
+			byNumber[r.Number] = r
+		}
+	}
+
+	// Walk the text, tracking exclusion zones where rewrites must not happen:
+	// inside markdown link text/URLs `[...](...)` and inside full URLs
+	// (http://, https://). Already-qualified `owner/repo#NNN` is handled by
+	// the lookbehind check on the byte immediately before `#`.
+	var out strings.Builder
+	out.Grow(len(text))
+
+	i := 0
+	for i < len(text) {
+		ch := text[i]
+
+		// Skip markdown link `[text](url)` as one opaque span.
+		if ch == '[' {
+			if end := findMarkdownLinkEnd(text, i); end > i {
+				out.WriteString(text[i:end])
+				i = end
+				continue
+			}
+		}
+
+		// Skip bare URLs (http:// or https://) as opaque spans so a `#NNN`
+		// inside a URL fragment or path is never rewritten.
+		if ch == 'h' || ch == 'H' {
+			if end := findURLEnd(text, i); end > i {
+				out.WriteString(text[i:end])
+				i = end
+				continue
+			}
+		}
+
+		// Detect `#NNN` (bare issue reference).
+		if ch == '#' && i+1 < len(text) && isDigit(text[i+1]) {
+			// Already-qualified refs like `owner/repo#NNN` have an alphanumeric,
+			// `-`, `_`, `.`, or `/` immediately before the `#`. Treat any such
+			// preceding character as "qualified" and skip rewriting.
+			if i > 0 && isQualifierByte(text[i-1]) {
+				out.WriteByte(ch)
+				i++
+				continue
+			}
+
+			// Read the number.
+			j := i + 1
+			for j < len(text) && isDigit(text[j]) {
+				j++
+			}
+			numStr := text[i+1 : j]
+			n, err := strconv.Atoi(numStr)
+			if err != nil {
+				out.WriteString(text[i:j])
+				i = j
+				continue
+			}
+
+			// Local hints win over upstream ambiguity.
+			if localIssueHints[n] {
+				out.WriteString(text[i:j])
+				i = j
+				continue
+			}
+
+			ref, ok := byNumber[n]
+			if !ok {
+				out.WriteString(text[i:j])
+				i = j
+				continue
+			}
+
+			out.WriteString(ref.Owner)
+			out.WriteByte('/')
+			out.WriteString(ref.Repo)
+			out.WriteByte('#')
+			out.WriteString(numStr)
+			i = j
+			continue
+		}
+
+		out.WriteByte(ch)
+		i++
+	}
+	return out.String()
+}
+
+// findMarkdownLinkEnd returns the byte offset just past a `[text](url)` span
+// starting at i, or i if no complete span is present. Nested brackets inside
+// link text are not handled (rare, and the worst case is we treat them as
+// non-link prose, which is safe).
+func findMarkdownLinkEnd(s string, i int) int {
+	if i >= len(s) || s[i] != '[' {
+		return i
+	}
+	closeBracket := strings.IndexByte(s[i+1:], ']')
+	if closeBracket < 0 {
+		return i
+	}
+	closeBracket += i + 1
+	if closeBracket+1 >= len(s) || s[closeBracket+1] != '(' {
+		return i
+	}
+	closeParen := strings.IndexByte(s[closeBracket+2:], ')')
+	if closeParen < 0 {
+		return i
+	}
+	return closeBracket + 2 + closeParen + 1
+}
+
+// findURLEnd returns the byte offset just past an `http://` or `https://`
+// URL starting at i, or i if no URL begins there. URL termination is at the
+// first whitespace, closing bracket/paren, or end-of-string.
+func findURLEnd(s string, i int) int {
+	rest := s[i:]
+	if !strings.HasPrefix(strings.ToLower(rest), "http://") && !strings.HasPrefix(strings.ToLower(rest), "https://") {
+		return i
+	}
+	end := i
+	for end < len(s) {
+		c := s[end]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == ')' || c == ']' || c == '>' {
+			break
+		}
+		end++
+	}
+	return end
+}
+
+func isDigit(b byte) bool {
+	return b >= '0' && b <= '9'
+}
+
+func isQualifierByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9') ||
+		b == '-' || b == '_' || b == '.' || b == '/'
 }

--- a/internal/comment/sanitize.go
+++ b/internal/comment/sanitize.go
@@ -115,6 +115,17 @@ func rewriteBareUpstreamRefs(text string, upstreamRefs []UpstreamRef, localIssue
 			}
 		}
 
+		// Skip backtick code spans as opaque so `#NNN` inside inline code
+		// (or fenced code blocks) is never rewritten. Unterminated runs fall
+		// through and are emitted literally.
+		if ch == '`' {
+			if end := findCodeSpanEnd(text, i); end > i {
+				out.WriteString(text[i:end])
+				i = end
+				continue
+			}
+		}
+
 		// Skip bare URLs (http:// or https://) as opaque spans so a `#NNN`
 		// inside a URL fragment or path is never rewritten.
 		if ch == 'h' || ch == 'H' {
@@ -206,7 +217,14 @@ func findMarkdownLinkEnd(s string, i int) int {
 // first whitespace, closing bracket/paren, or end-of-string.
 func findURLEnd(s string, i int) int {
 	rest := s[i:]
-	if !strings.HasPrefix(strings.ToLower(rest), "http://") && !strings.HasPrefix(strings.ToLower(rest), "https://") {
+	// Only lower-case the short prefix needed for the scheme check; lowering
+	// the entire remaining string would be O(n) per `h` byte encountered.
+	prefix := rest
+	if len(prefix) > 8 {
+		prefix = prefix[:8]
+	}
+	lowered := strings.ToLower(prefix)
+	if !strings.HasPrefix(lowered, "http://") && !strings.HasPrefix(lowered, "https://") {
 		return i
 	}
 	end := i
@@ -218,6 +236,44 @@ func findURLEnd(s string, i int) int {
 		end++
 	}
 	return end
+}
+
+// findCodeSpanEnd returns the byte offset just past a backtick-delimited code
+// span (or fenced code block) starting at i, or i if the span is unterminated.
+// Single-backtick spans `text` and multi-backtick spans ``text`` are supported,
+// where the opening run length determines the closing run length. Triple
+// backticks (```...```) are handled the same way, which transparently covers
+// fenced code blocks. Unterminated runs return i so the caller falls through
+// and emits the backtick(s) literally.
+func findCodeSpanEnd(s string, i int) int {
+	if i >= len(s) || s[i] != '`' {
+		return i
+	}
+	// Count opening backtick run length.
+	runLen := 0
+	for i+runLen < len(s) && s[i+runLen] == '`' {
+		runLen++
+	}
+	// Search for a closing run of exactly the same length (not part of a
+	// longer run). Scan forward looking for matching backtick runs.
+	j := i + runLen
+	for j < len(s) {
+		if s[j] != '`' {
+			j++
+			continue
+		}
+		closeLen := 0
+		for j < len(s) && s[j] == '`' {
+			closeLen++
+			j++
+		}
+		if closeLen == runLen {
+			return j
+		}
+		// Wrong-length run: continue searching past it.
+	}
+	// Unterminated: caller emits literal.
+	return i
 }
 
 func isDigit(b byte) bool {

--- a/internal/comment/sanitize_test.go
+++ b/internal/comment/sanitize_test.go
@@ -92,6 +92,145 @@ func TestSanitizeLLMOutputStripsGFMImages(t *testing.T) {
 	}
 }
 
+func TestExtractUpstreamRefs(t *testing.T) {
+	tests := []struct {
+		name string
+		urls []string
+		want []UpstreamRef
+	}{
+		{
+			name: "issue URL parsed",
+			urls: []string{"https://github.com/electron/electron/issues/50106"},
+			want: []UpstreamRef{{Owner: "electron", Repo: "electron", Number: 50106}},
+		},
+		{
+			name: "pull URL parsed",
+			urls: []string{"https://github.com/electron/electron/pull/50300"},
+			want: []UpstreamRef{{Owner: "electron", Repo: "electron", Number: 50300}},
+		},
+		{
+			name: "non-issue URL ignored",
+			urls: []string{"https://example.com/docs/login", "https://github.com/electron/electron/releases/tag/v39.0.0"},
+			want: nil,
+		},
+		{
+			name: "mixed URLs return only issue/PR",
+			urls: []string{
+				"https://example.com/docs",
+				"https://github.com/electron/electron/issues/50106",
+				"",
+			},
+			want: []UpstreamRef{{Owner: "electron", Repo: "electron", Number: 50106}},
+		},
+		{
+			name: "empty input",
+			urls: nil,
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractUpstreamRefs(tt.urls)
+			if len(got) != len(tt.want) {
+				t.Fatalf("ExtractUpstreamRefs() len = %d, want %d (got=%v)", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("ExtractUpstreamRefs()[%d] = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRewriteBareUpstreamRefs(t *testing.T) {
+	electron := []UpstreamRef{{Owner: "electron", Repo: "electron", Number: 50106}}
+
+	tests := []struct {
+		name       string
+		in         string
+		refs       []UpstreamRef
+		localHints map[int]bool
+		want       string
+	}{
+		{
+			name: "rewrites bare upstream ref",
+			in:   "this looks like #50106 in Electron",
+			refs: electron,
+			want: "this looks like electron/electron#50106 in Electron",
+		},
+		{
+			name: "leaves unrelated bare ref unchanged (local default)",
+			in:   "see #123 for context",
+			refs: electron,
+			want: "see #123 for context",
+		},
+		{
+			name:       "ambiguity prefers local when hint set matches",
+			in:         "see #50106 in this repo",
+			refs:       electron,
+			localHints: map[int]bool{50106: true},
+			want:       "see #50106 in this repo",
+		},
+		{
+			name: "idempotent on already-qualified output",
+			in:   "this looks like electron/electron#50106 in Electron",
+			refs: electron,
+			want: "this looks like electron/electron#50106 in Electron",
+		},
+		{
+			name: "leaves already-qualified ref unchanged",
+			in:   "duplicate of electron/electron#50106",
+			refs: electron,
+			want: "duplicate of electron/electron#50106",
+		},
+		{
+			name: "leaves number inside markdown link unchanged",
+			in:   "see [#50106](https://github.com/electron/electron/issues/50106) for details",
+			refs: electron,
+			want: "see [#50106](https://github.com/electron/electron/issues/50106) for details",
+		},
+		{
+			name: "leaves number inside bare URL unchanged",
+			in:   "see https://github.com/electron/electron/issues/50106 for details",
+			refs: electron,
+			want: "see https://github.com/electron/electron/issues/50106 for details",
+		},
+		{
+			name: "no upstream refs returns text untouched",
+			in:   "see #50106 for details",
+			refs: nil,
+			want: "see #50106 for details",
+		},
+		{
+			name: "rewrites at start of string",
+			in:   "#50106 is the upstream report",
+			refs: electron,
+			want: "electron/electron#50106 is the upstream report",
+		},
+		{
+			name: "punctuation after bare ref preserved",
+			in:   "fixed by #50106. Try the latest build.",
+			refs: electron,
+			want: "fixed by electron/electron#50106. Try the latest build.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rewriteBareUpstreamRefs(tt.in, tt.refs, tt.localHints)
+			if got != tt.want {
+				t.Fatalf("rewriteBareUpstreamRefs() =\n  %q\nwant\n  %q", got, tt.want)
+			}
+			// Idempotency: applying twice produces the same output.
+			twice := rewriteBareUpstreamRefs(got, tt.refs, tt.localHints)
+			if twice != got {
+				t.Fatalf("rewriteBareUpstreamRefs() not idempotent:\n  first  = %q\n  second = %q", got, twice)
+			}
+		})
+	}
+}
+
 func TestSanitizeURL(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/comment/sanitize_test.go
+++ b/internal/comment/sanitize_test.go
@@ -214,6 +214,43 @@ func TestRewriteBareUpstreamRefs(t *testing.T) {
 			refs: electron,
 			want: "fixed by electron/electron#50106. Try the latest build.",
 		},
+		{
+			name:       "current issue protected via localIssueHints",
+			in:         "this issue (#50106) reproduces the bug",
+			refs:       electron,
+			localHints: map[int]bool{50106: true},
+			want:       "this issue (#50106) reproduces the bug",
+		},
+		{
+			name: "single-backtick code span excluded",
+			in:   "see `#50106` for context",
+			refs: electron,
+			want: "see `#50106` for context",
+		},
+		{
+			name: "code span among normal prose",
+			in:   "see #50106 in `#50106` and #50106 again",
+			refs: electron,
+			want: "see electron/electron#50106 in `#50106` and electron/electron#50106 again",
+		},
+		{
+			name: "unterminated backtick falls through",
+			in:   "stray ` and #50106",
+			refs: electron,
+			want: "stray ` and electron/electron#50106",
+		},
+		{
+			name: "fenced code block excluded",
+			in:   "before\n```\n#50106\n```\nafter #50106",
+			refs: electron,
+			want: "before\n```\n#50106\n```\nafter electron/electron#50106",
+		},
+		{
+			name: "double-backtick span excluded",
+			in:   "text ``contains ` backtick and #50106`` and #50106 outside",
+			refs: electron,
+			want: "text ``contains ` backtick and #50106`` and electron/electron#50106 outside",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/phases/synthesis.go
+++ b/internal/phases/synthesis.go
@@ -56,6 +56,7 @@ Rules:
 - Never greet the user or sign off.
 - If context documents relate to missing information, connect them (e.g., "this looks like X, and debug logs would help confirm").
 - Use markdown sparingly: short paragraphs, a checklist only when 3+ items are missing.
+- For external/upstream issue references (e.g. another GitHub repo), never write a bare ` + "`#NNN`" + ` — GitHub will auto-link it against this repo. Use the qualified ` + "`OWNER/REPO#NNN`" + ` form (e.g. ` + "`electron/electron#50106`" + `) or a markdown link to the CONTEXT doc_url. Bare ` + "`#NNN`" + ` is reserved for issues in this repo.
 - If nothing useful was found, return exactly: EMPTY
 
 Return a JSON object with a single field "comment" containing your markdown response (or "EMPTY").`

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -499,7 +499,7 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 			// qualified form so GitHub doesn't auto-link them against the
 			// host repo, then append debug instructions and footer.
 			body = comment.SanitizeLLMOutput(synthResult)
-			body = comment.RewriteBareUpstreamRefs(body, collectUpstreamRefs(synthInput), nil)
+			body = comment.RewriteBareUpstreamRefs(body, collectUpstreamRefs(synthInput), map[int]bool{issue.Number: true})
 			if di := comment.DebugInstructions(result); di != "" {
 				body += "\n\n" + di
 			}
@@ -665,7 +665,7 @@ func (h *Handler) handleRetriage(ctx context.Context, installationID int64, repo
 			// qualified form so GitHub doesn't auto-link them against the
 			// host repo, then append debug instructions and footer.
 			body = comment.SanitizeLLMOutput(synthResult)
-			body = comment.RewriteBareUpstreamRefs(body, collectUpstreamRefs(synthInput), nil)
+			body = comment.RewriteBareUpstreamRefs(body, collectUpstreamRefs(synthInput), map[int]bool{issue.Number: true})
 			if di := comment.DebugInstructions(result); di != "" {
 				body += "\n\n" + di
 			}

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -495,8 +495,11 @@ func (h *Handler) handleOpened(ctx context.Context, installationID int64, repo s
 			issueLog.Error("synthesis failed, falling back to concatenation", "error", synthErr)
 			body = comment.Build(result)
 		} else if synthResult != "" {
-			// Sanitise LLM output, append debug instructions and footer
+			// Sanitise LLM output, rewrite bare upstream refs to their
+			// qualified form so GitHub doesn't auto-link them against the
+			// host repo, then append debug instructions and footer.
 			body = comment.SanitizeLLMOutput(synthResult)
+			body = comment.RewriteBareUpstreamRefs(body, collectUpstreamRefs(synthInput), nil)
 			if di := comment.DebugInstructions(result); di != "" {
 				body += "\n\n" + di
 			}
@@ -658,8 +661,11 @@ func (h *Handler) handleRetriage(ctx context.Context, installationID int64, repo
 			issueLog.Error("synthesis failed, falling back to concatenation", "error", synthErr)
 			body = comment.Build(result)
 		} else if synthResult != "" {
-			// Sanitise LLM output, append debug instructions and footer
+			// Sanitise LLM output, rewrite bare upstream refs to their
+			// qualified form so GitHub doesn't auto-link them against the
+			// host repo, then append debug instructions and footer.
 			body = comment.SanitizeLLMOutput(synthResult)
+			body = comment.RewriteBareUpstreamRefs(body, collectUpstreamRefs(synthInput), nil)
 			if di := comment.DebugInstructions(result); di != "" {
 				body += "\n\n" + di
 			}
@@ -981,6 +987,24 @@ func sanitizeBody(body string, maxLen int) string {
 		result = result[:maxLen]
 	}
 	return result
+}
+
+// collectUpstreamRefs gathers GitHub issue/PR references from the doc URLs
+// that were sent into the synthesis prompt, so synthesised prose can have
+// bare `#NNN` references rewritten to their qualified `OWNER/REPO#NNN` form.
+func collectUpstreamRefs(input phases.SynthesisInput) []comment.UpstreamRef {
+	urls := make([]string, 0, len(input.Phase2)+len(input.Phase4a))
+	for _, s := range input.Phase2 {
+		if s.DocURL != "" {
+			urls = append(urls, s.DocURL)
+		}
+	}
+	for _, c := range input.Phase4a {
+		if c.DocURL != "" {
+			urls = append(urls, c.DocURL)
+		}
+	}
+	return comment.ExtractUpstreamRefs(urls)
 }
 
 func collectPhasesRun(r comment.TriageResult, synthesized bool) []string {


### PR DESCRIPTION
## Summary

When the synthesis LLM weaves an upstream issue reference into prose like *"this looks like #50106 in Electron"*, GitHub's autolinker rewrites `#50106` against the comment's host repo. On `IsmaelMartinez/teams-for-linux` that becomes `teams-for-linux/issues/50106`, pointing readers to a non-existent issue in the wrong tracker. The `doc_url` we send to the LLM is correct, and markdown-link form renders fine — only bare `#NNN` references slip through.

This PR adds a two-step fix:

- Prompt-side (`internal/phases/synthesis.go`): one extra rule in the synthesis system prompt instructing the LLM to use the qualified `OWNER/REPO#NNN` form (e.g. `electron/electron#50106`) or a markdown link to the CONTEXT `doc_url` for any external/upstream reference. Bare `#NNN` is reserved for issues in the host repo.
- Post-process side (`internal/comment/sanitize.go` + `internal/webhook/handler.go`): a new `RewriteBareUpstreamRefs` walks bare `#NNN` matches in synthesised prose and rewrites them against the upstream refs parsed from the `doc_url`s sent into the prompt this turn (e.g. `https://github.com/electron/electron/issues/50106` → `electron`/`electron`/`50106`). It runs after `SanitizeLLMOutput` for the synthesised path only; the deterministic fallback in `comment.Build` already constructs links explicitly.

### Boundaries

- Numbers inside markdown link text/URLs (`[..](..)`) are not rewritten.
- Numbers inside bare `http(s)://` URLs are not rewritten.
- Already-qualified refs (`owner/repo#NNN`) are not rewritten (idempotent).
- When a number appears in `localIssueHints`, local wins (bare `#NNN` in maintainer prose conventionally means the host repo, so we treat that as the safer default for ambiguity).

## Test plan

Table-driven tests added in `internal/comment/sanitize_test.go`:

- [x] `TestExtractUpstreamRefs`: parses GitHub issue and pull URLs into `UpstreamRef`, ignores non-issue/PR URLs and empty input.
- [x] `TestRewriteBareUpstreamRefs` covers: rewrite of bare upstream ref, no-op for unrelated bare ref (treated as local), ambiguity prefers local hint, idempotency on already-qualified output, already-qualified ref untouched, markdown link untouched, full URL untouched, no upstream refs returns text untouched, ref at start of string, punctuation after ref preserved. Each case also asserts idempotency by re-running the rewrite.
- [x] `go test ./internal/comment/... ./internal/phases/... ./internal/webhook/...` passes locally
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./internal/comment/... ./internal/phases/... ./internal/webhook/...` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)