### PR TITLE
ci: monthly Electron upstream refresh workflow

### DIFF
--- a/.github/workflows/upstream-refresh.yml
+++ b/.github/workflows/upstream-refresh.yml
@@ -1,0 +1,68 @@
+name: Monthly Upstream Refresh
+
+# Refreshes upstream Electron release notes and issue summaries in the
+# vector store on the first day of each month. Active Electron majors are
+# regenerated via scripts/generate-upstream-index.sh and re-seeded through
+# `./seed features`. The committed data/electron-vNN-*.json snapshots are
+# left untouched — the live store is the source of truth; the snapshots
+# are kept for reference and reproducibility of the initial seed.
+
+on:
+  schedule:
+    - cron: '0 6 1 * *'
+  workflow_dispatch:
+    inputs:
+      versions:
+        description: 'Comma-separated active Electron majors (e.g. "40,41")'
+        required: false
+        default: '40,41'
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Build seed binary
+        run: go build -o seed ./cmd/seed
+
+      - name: Refresh upstream Electron docs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DATABASE_URL: ${{ secrets.TF_VAR_DATABASE_URL }}
+          GEMINI_API_KEY: ${{ secrets.TF_VAR_GEMINI_API_KEY }}
+          VERSIONS: ${{ inputs.versions || '40,41' }}
+        run: |
+          set -euo pipefail
+          IFS=',' read -ra MAJORS <<< "$VERSIONS"
+          for raw in "${MAJORS[@]}"; do
+            major="$(echo "$raw" | tr -d '[:space:]')"
+            if [[ -z "$major" ]]; then continue; fi
+
+            echo "::group::Electron v${major} releases"
+            ./scripts/generate-upstream-index.sh \
+              --repo electron/electron \
+              --type releases \
+              --version "$major" \
+              --doc-type upstream_release \
+              > "/tmp/electron-v${major}-releases.json"
+            ./seed features "/tmp/electron-v${major}-releases.json"
+            echo "::endgroup::"
+
+            echo "::group::Electron v${major} issues"
+            ./scripts/generate-upstream-index.sh \
+              --repo electron/electron \
+              --type issues \
+              --version "${major}-x-y" \
+              --doc-type upstream_issue \
+              > "/tmp/electron-v${major}-issues.json"
+            ./seed features "/tmp/electron-v${major}-issues.json"
+            echo "::endgroup::"
+          done

--- a/docs/plans/2026-03-04-roadmap.md
+++ b/docs/plans/2026-03-04-roadmap.md
@@ -306,7 +306,7 @@ Open issues for future consideration:
 - ~~Deepen repo-butler integration~~ Both MCP servers shipped, integration is live
 - Q4 (retrospective compliance audit) — when 50+ sessions accumulate, write an agent.
 - Evaluate `actions/ai-inference` + GitHub AI labeler as a zero-infrastructure alternative for issue labelling.
-- ~~Seed Electron 40 and 41 upstream docs~~ DONE (PR #135, 2026-05-03). v40 and v41 (releases + issues) seeded; v39 retained until v42 lands. The seed script now truncates summaries at the last newline boundary to avoid broken markdown links. A monthly refresh GitHub Action remains a worthwhile follow-up.
+- ~~Seed Electron 40 and 41 upstream docs~~ DONE (PR #135, 2026-05-03). v40 and v41 (releases + issues) seeded; v39 retained until v42 lands. The seed script now truncates summaries at the last newline boundary to avoid broken markdown links. ~~A monthly refresh GitHub Action remains a worthwhile follow-up.~~ DONE (2026-05-04, `.github/workflows/upstream-refresh.yml`): cron on the 1st of each month at 06:00 UTC re-seeds the active majors via the existing seed pipeline; defaults are overridable via `workflow_dispatch`.
 - ~~Stop bare `#NNN` references from auto-linking against the consumer repo when the actual reference is upstream~~ DONE (PR #136, 2026-05-03). Two-step fix shipped: synthesis prompt tightened, and `RewriteBareUpstreamRefs` in `internal/comment/sanitize.go` rewrites bare `#NNN` matches against the upstream doc URLs sent into the prompt while preserving local refs, code spans, and existing markdown links.
 
 ## What We're Not Doing


### PR DESCRIPTION
## Summary
- New `.github/workflows/upstream-refresh.yml` running on the 1st of each month at 06:00 UTC
- Regenerates and re-seeds upstream Electron releases + issues for the active majors (default `40,41`) via the existing `generate-upstream-index.sh` + `./seed features` pipeline
- `workflow_dispatch` input lets a maintainer override the active majors (e.g. add `42` when it lands, or kick a one-off refresh)
- Roadmap updated to mark the monthly-refresh follow-up as DONE

The committed `data/electron-vNN-*.json` snapshots are intentionally untouched — the live store is the source of truth, and the snapshots are kept for reference.

## Test plan
- [ ] Manual `workflow_dispatch` run with default `40,41` succeeds end-to-end (build seed binary, regenerate JSON, re-seed both doc types per major)
- [ ] Confirm next scheduled run (1st of next month) executes and that re-seeding is idempotent (upserts, no duplicate documents in the vector store)

🤖 Generated with [Claude Code](https://claude.com/claude-code)