### PR TITLE
fix: bump Go to 1.26.3 to clear stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IsmaelMartinez/github-issue-triage-bot
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/IsmaelMartinez/github-issue-triage-bot
 
-go 1.26.3
+go 1.26
+
+toolchain go1.26.3
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.18.0


### PR DESCRIPTION
## Summary
- Bumps the `go` directive in `go.mod` from 1.26.2 to 1.26.3 to resolve the failing `govulncheck` step (4 stdlib advisories: GO-2026-4980, GO-2026-4971, GO-2026-4918, plus one further `html/template` advisory).
- Unblocks PR #138 (monthly upstream Electron refresh workflow) whose `test` job was failing on the same CVE.
- Workflows already use `go-version-file: go.mod` so no `.github/workflows` edits are needed.

## Test plan
- [ ] `test` job passes on CI (run `go test ./...` and `govulncheck ./...` against Go 1.26.3)
- [ ] CodeQL `analyze` stays green
- [ ] Deploy job remains skipped on PR

Closes #140