### PR TITLE
docs(plan): reflect what shipped, record pilot results

### DIFF
--- a/docs/plans/2026-05-15-skill-driven-triage-design.md
+++ b/docs/plans/2026-05-15-skill-driven-triage-design.md
@@ -1,7 +1,7 @@
 # Skill-driven triage design
 
-Status: proposed
-Date: 2026-05-15
+Status: implemented (Tasks 1-3); Task 4 pilot complete, retirement of Go-side phases deferred pending real-use evidence
+Date: 2026-05-15 (updated 2026-05-16)
 Relates to: `docs/plans/2026-04-22-research-brief-bot-design.md` (closes the deferred "promotion drafter" question)
 Relates to: `docs/plans/2026-04-22-retrieval-engine-plan.md` (consumes the shipped retrieval engine)
 Supersedes: nothing (additive)
@@ -52,102 +52,61 @@ Outside this repo:
 
 ## Tasks
 
-### Task 1: Add `get_brief_preview` MCP tool
+### Task 1: Add `get_brief_preview` MCP tool — DONE
 
-Files:
-- Create: `internal/mcp/tools/brief_preview.go`
-- Create: `internal/mcp/tools/brief_preview_test.go`
-- Modify: `internal/mcp/tools/tools.go` (register)
-- Modify: `cmd/mcp/main.go` (wire)
+Shipped in PR #144 (merged 2026-05-16, squash commit `4fce834`).
 
-- [ ] Write failing test in `brief_preview_test.go` covering: required args validation (repo, issue_number both required), pass-through of optional `hat`, HTTP body shaping, error mapping (404 → tool error, 500 → tool error), happy-path JSON decode.
-- [ ] Run `go test ./internal/mcp/tools/ -run TestBriefPreview` and confirm failure.
-- [ ] Implement `BriefPreview()` returning `Tool{Def, Handler}` in `brief_preview.go`. Mirror the `pending_triage.go` shape: tool def with name `get_brief_preview`, description, JSON-schema input (`repo` string required, `issue_number` integer required, `hat` string optional), handler that POSTs to `{baseURL}/brief-preview` with `{repo, issue_number, hat?}` body and returns the parsed JSON as the tool result.
-- [ ] Add `BriefPreview` to the tools registry in `tools.go` (parallel to `HealthStatus`, `PendingTriage`, `ReportTrends`, `SynthesisBriefing`).
-- [ ] Wire registration in `cmd/mcp/main.go`.
-- [ ] `go test ./...` → all green.
-- [ ] `golangci-lint run ./...` → clean.
+Files shipped:
+- `internal/mcp/tools/brief_preview.go` — tool definition and handler
+- `internal/mcp/tools/brief_preview_test.go` — table-driven unit tests covering def shape, missing-args, happy-path body shaping, optional hat field, auth header, HTTP error mapping, bad-JSON args
+- `internal/mcp/tools/tools.go` — added `postJSONWithBody` helper (the existing helpers did not support POST with a JSON body); `doRequest` signature extended to accept an optional body
+- `cmd/mcp/main.go` — registered the new tool; tool count `tools` log field bumped 4 → 5
+- `docs/adr/013-mcp-server.md` — amended to mention the fifth tool
 
-### Task 2: Seed `hats.md` in teams-for-linux
+The tool wraps `POST /brief-preview`. Signature: `get_brief_preview(repo, issue_number, hat?)`. Response is the unchanged JSON from the HTTP endpoint: `{class, similar_past_issues, docs, regression_prs, upstream_candidates}`. Allow-list enforcement happens server-side via the existing `allowedRepos` check.
 
-Files:
-- Create: `IsmaelMartinez/teams-for-linux:.github/hats.md`
+### Task 2: Seed `hats.md` in teams-for-linux — DONE
 
-The bot's hats parser (`internal/hats/parser.go`) accepts a markdown file with one `## hat-name` per hat, body containing freeform prose plus optional bracketed metadata keys (`retrieval_boost: keyword1,keyword2`, `posture: workaround-menu | single-hypothesis | causal-narrative | demand-gating | config-check`, `anchor_issues: 2169,2138`).
+Shipped in IsmaelMartinez/teams-for-linux PR #2548 (merged 2026-05-15, squash commit on main). Three gemini-code-assist medium-priority review comments were addressed before merge: `internal-regression-network` Phase 1 asks now user-facing only (maintainer-side checks moved to "When to pick"); `packaging` "When to pick" tightened to discriminate from `tray-notifications`; `auth-network-edge` Chromium-shared-plumbing interpretation caveat moved out of Phase 1 asks and into "When to pick".
 
-The eight initial hats, drawn from the research-brief design's seed list and the skill's section 4 categories:
+Nine hats live at `.github/hats.md` in teams-for-linux (eight from the design plus `other` as fallback). Parser verification (`internal/hats/parser.go`) returned correct postures, retrieval-boost keywords, and anchor issue numbers for every hat.
 
-- [ ] `display-session-media` — screen-share, camera, screen-capture, window-picker, display-server interactions. Posture: causal-narrative when one mechanism dominates, workaround-menu when display server + GPU vendor + compositor + Electron version split the diagnosis. Anchors: #2169 (Electron 39.8.2 VideoFrame fix), #2138, #2529 (multi-account session bound to root only).
-- [ ] `internal-regression-network` — auth, network, SSO, certificate, MITM proxy regressions where a TFL release coincides with the symptom appearing. Posture: causal-narrative. Anchors: #2293.
-- [ ] `tray-notifications` — tray icon, notification rendering, notification sound, badge, MQTT status. Posture: single-hypothesis when one code point is clearly responsible, workaround-menu when configuration permutations matter. Anchors: #2239, #2248, #2095.
-- [ ] `upstream-blocked` — Electron, Chromium, Microsoft Teams web, or system-portal limitations with no current workaround. Posture: blocked-on-upstream tag, document the limitation. Anchors: #2335, #2137.
-- [ ] `packaging` — snap, flatpak, AUR, deb, rpm-specific failures that would not reproduce on other packaging. Posture: config-check. Anchors: #2239.
-- [ ] `configuration-cli` — config-file or command-line option that toggles the symptom; user does not know the right setting. Posture: config-check. Anchors: #2143, #2205.
-- [ ] `enhancement-demand-gating` — feature request from a non-contributor. Posture: demand-gating-needed. Surface the four extension patterns from the skill's section 4 (main-process surface, webRequest interception, React-store hijack, floating UI plus synthetic events). Anchor: #2107.
-- [ ] `auth-network-edge` — SSO, FIDO2, federated auth, certificate, network edge that needs end-to-end diagnostic command paste. Posture: workaround-menu. Anchors: #2326, #2364.
+Effect: `POST /brief-preview` now returns `class: <hat-name>` when the caller passes a `hat` parameter and applies `ApplyHatBoost` to the doc retrieval. The empirical effect was confirmed during the Task 4 evaluation (see below): on three of seven hatted simulations the hat-aware boost surfaced load-bearing ADRs that unboosted retrieval would have missed.
 
-Each hat is one short paragraph, not bullets. The file stays under 2000 tokens (the loader's soft size guard) so the entire taxonomy fits in the brief generator's system prompt once that ships. The maintainer commits this directly to teams-for-linux; the bot's `config.Cache` picks it up via the Contents API on next request (5-minute TTL).
+### Task 3: Skill integration step — DONE
 
-### Task 3: Skill integration step
+Applied 2026-05-16 directly to `~/.claude/skills/teams-for-linux-issue-review/SKILL.md`. Section 1c sits between the sibling-ticket sweep (1a) and opening the local source (2), instructing the skill to call `get_brief_preview` with the appropriate hat from `.github/hats.md`, treat the response as input not output, apply the four-column check before citing any neighbour, and note the spurious `[802]` upstream candidate to ignore for now.
 
-File:
-- Modify: `~/.claude/skills/teams-for-linux-issue-review/SKILL.md`
+**Distribution decision (2026-05-16):** the skill stays local to the maintainer's Claude config and is *not* committed to either this repo or teams-for-linux. The skill encodes the maintainer's personal review style and is also used to review external PRs, so committing it to teams-for-linux risks contributors interpreting it as the canonical project policy rather than a personal workflow. A generic template could be extracted into this repo if and when a second consumer of the bot wants the same pattern, but that is deferred until concrete second-consumer feedback exists.
 
-Insert a new subsection between current sections 1a and 2:
+### Task 4: Quality evaluation — PILOT COMPLETE, decision deferred
 
-```
-### 1c. Pull bot retrieval context
+Ran on 2026-05-15 against the last ten open teams-for-linux issues. Drafts posted as `[Sim] #NNNN: <title>` issues in `IsmaelMartinez/teams-for-linux-shadow`, cross-linked to the existing `[Triage]` produced by the Go pipeline.
 
-After the sibling-ticket sweep and before opening the local source, call the
-triage bot via MCP to pull its retrieval bundle for the issue:
+Simulation set:
 
-`mcp__triage-bot__get_brief_preview` with `repo=IsmaelMartinez/teams-for-linux`
-and `issue_number=NNNN`.
+| Source | [Sim] | [Triage] | Hat | Hat-aware? |
+|---|---|---|---|---|
+| #2541 | shadow#97 | shadow#95 | other | no (pilot, hats.md not yet merged) |
+| #2534 | shadow#99 | shadow#91 | other | no (pilot) |
+| #2530 | shadow#98 | shadow#88 | other | no (pilot) |
+| #2536 | shadow#100 | shadow#93 | auth-network-edge | yes |
+| #2535 | shadow#101 | shadow#92 | upstream-blocked | yes |
+| #2529 | shadow#102 | shadow#87 | display-session-media | yes |
+| #2524 | shadow#103 | shadow#85 | enhancement-demand-gating | yes |
+| #2518 | shadow#104 | shadow#82 | other (taxonomy gap) | n/a |
+| #2512 | shadow#105 | shadow#81 | enhancement-demand-gating | yes |
+| #2508 | shadow#106 | shadow#80 | configuration-cli | yes |
 
-The response contains:
-- `class` — the hat the bot picked from `.github/hats.md` (or `other`)
-- `similar_past_issues` — top-5 semantic neighbours from the full corpus
-- `docs` — top-5 doc hits across ADR, roadmap, research, troubleshooting
-- `regression_prs` — merged PRs between reporter's working version and latest
-  release, only if the reporter named a working version
-- `upstream_candidates` — open `blocked` issues semantically close to this one,
-  used to flag Electron-release cross-references
+Findings:
 
-Read the bundle but do not trust the rankings blindly. The vector search has
-the same calibration failures simili-bot has shown (semantic neighbours can
-be older issues that share keywords but not root cause). Treat it as input,
-not output. Apply the four-column check from section 3e before citing any
-neighbour; verify any cited doc before quoting; the regression PR list is
-keyword-filtered and can include unrelated merges, so read the diffs before
-citing.
+The skill drafts outperformed `[Triage]` on every case. On the three cases where `[Triage]` had any opinion at all (`#95`, `#91`, `#92`), the skill produced a sharper diagnosis grounded in the local source rather than the bot's keyword-adjacent neighbour list. On the seven cases where `[Triage]` was a verbatim mirror of the issue body with no diagnostic content, the skill drafts added the missing analysis. The decision threshold in the original criterion ("7 or more cases") was met (10 of 10).
 
-The bot's retrieval adds three things `gh issue list --search` does not:
-semantic neighbours older than the keyword window, the doc index across all
-four classes, and the upstream-release cross-reference. Everything else you
-do yourself.
-```
+The strongest single value-add from the skill was reading local repo state to detect in-flight PRs that reference the issue: #2530's draft cited PR #2540 (the `.catch()` fix), #2524's draft confirmed PR #2543 had already shipped and closed the loop, #2529's draft cited PR #2533 on develop, #2518's draft credited PR #2520's `--disable-quic` approach, #2536's draft cited PR #2250's regex update from two months prior. The Go pipeline cannot produce this kind of context because it does not check open or merged PRs against the issue.
 
-This addition is small (one section). It changes the skill's behaviour from "gh-only" to "gh plus bot retrieval, both as inputs," without changing the skill's calibration discipline, anti-patterns, or voice. The skill remains the brain.
+Hat-aware retrieval was material on three of seven hatted simulations: `display-session-media` for #2529 surfaced ADR 010 and ADR 008 (load-bearing); `configuration-cli` for #2508 surfaced the three Electron upstream PRs justifying the ozone-platform default change; `auth-network-edge` for #2536 surfaced the closest precedent (#1059). On three more (`upstream-blocked` for #2535, `enhancement-demand-gating` for #2524 and #2512) the hat was directionally right but the neighbour list still mostly keyword-noisy. On one (`other` for #2518) the hat was missing from the taxonomy and the unboosted retrieval surfaced a structurally similar but mechanism-wrong upstream Electron PR pair (#50559/#50670) that misled the bot's already-posted public reply.
 
-### Task 4: Quality evaluation
-
-Files:
-- Create: `docs/plans/2026-05-15-skill-driven-triage-eval.md` (or append to this plan)
-
-Run the integrated skill against the most recent 10 open issues in teams-for-linux. For each, post the skill's draft to the shadow repo as a `[Sim] [class] #NNNN: <title>` issue cross-linked to the existing `[Triage]` produced by the current Go pipeline. The maintainer reads both and records:
-
-- which output surfaced the more useful diagnosis or workaround
-- which output contained any factual errors or fabricated references
-- which output's "next steps" were the ones the maintainer would actually take
-- a one-line note per issue capturing the qualitative difference
-
-After 10 issues, decide:
-
-- if the integrated skill outperforms in 7 or more cases, expand the trial to 30 more issues and prepare a Phase 5 to retire Phase 2/4a/synthesis from the public bot comment path
-- if the bot's Phase 2/4a/synthesis output is competitive, leave both running for another month and re-evaluate
-- if the skill underperforms, document why in the open-questions section below and either tune the skill or rework retrieval
-
-The eval is structured for honesty: the simulated outputs go to shadow (low blast radius), the comparison is recorded against existing `[Triage]` outputs already posted there, and no public-comment policy changes until the decision is taken.
+Decision: not retiring the Go-side phases yet. The simulation evidence is sufficient by the original criterion, but several wins (in-flight PR detection, local code reading) come from the skill operating in a Claude Code session rather than from the bot's retrieval, and the durable feedback preference is to keep the skill manually invoked. Until the skill is in routine real use rather than a one-shot simulation batch, retiring Phase 2/4a/synthesis from the public bot comment path is premature. Re-evaluate after thirty real-use invocations.
 
 ## Testing
 
@@ -171,12 +130,24 @@ The skill output is drafted in a Claude Code session, posted by the maintainer (
 
 The `[Sim]` shadow issues during the eval are clearly marked and cross-linked to existing `[Triage]` issues, so the maintainer can read both without confusion. The shadow repo is private to the maintainer and not visible to users.
 
+## Follow-ups identified during the pilot
+
+Three taxonomy and retrieval observations from the simulation that became concrete follow-ups:
+
+A `downloads` hat is worth adding. Two of the last ten issues (#2512 feature request for progress indicators, #2518 concurrent download stall) had no clean fit in the current taxonomy and defaulted to `other` or `enhancement-demand-gating`. The latter was a stretch in both cases. A `downloads` hat with keyword boost on `download`, `will-download`, `DownloadItem`, `shell.openExternal`, `setDisplayMediaRequestHandler` would route similar future cases properly. Defer until a third download-area issue accumulates.
+
+A `tracking-validation` hat is worth adding. #2508 (the ozone-platform default validation tracking issue) is a cohort-roll-up shape, not a diagnostic shape. `configuration-cli` was the closest available match but its Phase 1 asks are wrong for a tracking issue. The new hat would have a `tracking-validation` posture that signals "do not run Phase 1 missing-info checks on this issue, summarise the cohort instead." Worth adding when a second tracking issue surfaces; one example is not yet enough to anchor a hat.
+
+The `upstream_candidates: [802]` constant returned by `/brief-preview` for every query is a bug, not a feature. The FIDO2 thread #802 is being returned regardless of the issue, polluting the hat-aware bundle with a spurious upstream cross-reference. Root cause is most likely in `FindSimilarBlockedIssues` (the only `blocked` issue with a recent embedding) but worth a focused look at the query and the threshold. File as a separate bug.
+
 ## Open questions
 
-How does the skill handle the case where `/brief-preview` returns empty similar-issues or empty docs? It needs to keep working (the brief endpoint already returns empty slices rather than 500). The skill's section 1c needs a line saying "absence is data": if the bot finds nothing semantically close, that is itself a signal that the issue is novel.
+~~How does the skill handle empty similar-issues or empty docs?~~ Answered in the shipped section 1c edit: "Absence is data too: if the bot finds nothing semantically close, that itself is evidence the issue is novel."
 
-How do we handle the simili-bot trial overlap? Both simili-bot's similar-thread list and the bot's `similar_past_issues` claim to surface neighbours. The skill currently warns against trusting simili-bot's confidence numbers. The skill needs the same warning about the bot's vector hits. The simili-bot trial closes adopt/extend/drop after about 10 more issues (per the trial decision doc); the answer can wait until then.
+How do we handle the simili-bot trial overlap? Still open. Both simili-bot's similar-thread list and the bot's `similar_past_issues` surface neighbours. The skill's existing anti-pattern warning about simili-bot's duplicate confidence numbers now also applies to the bot's vector hits, as observed across all ten simulations. The simili-bot trial closes adopt/extend/drop after about ten more issues per `docs/decisions/007-simili-bot-trial.md`; revisit then.
 
-Should the skill's section 1c also pull from `mcp__triage-bot__get_synthesis_briefing` for context on weekly clusters and drift? Maybe, but that pulls cross-issue context that may not be relevant to one ticket. Hold off until the brief-preview integration has been validated.
+Should the skill's section 1c also pull from `mcp__triage-bot__get_synthesis_briefing` for context on weekly clusters and drift? Hold off. The brief-preview integration is the validated path; pulling weekly cross-issue context for a single-ticket review would add noise more often than signal.
 
-What happens to the existing `internal/agent` flow (research synthesis on enhancement issues, lgtm gate, shadow promotion)? That path is orthogonal: it triggers on enhancement issues and produces `[Research]` shadow output. The skill-driven triage covers all issue types. The two can coexist; if the eval supports retiring Phase 2/4a/synthesis, the `internal/agent` research path can be revisited separately.
+What happens to the existing `internal/agent` flow (research synthesis on enhancement issues, lgtm gate, shadow promotion)? Still orthogonal. It triggers on enhancement issues and produces `[Research]` shadow output. The skill-driven triage covers all issue types. Both can coexist until the Phase 2/4a/synthesis retirement decision is taken; at that point the `internal/agent` research path is revisited separately.
+
+When should retirement of Go-side phases (Phase 2, 4a, synthesis) be reconsidered? After thirty real-use skill invocations on public teams-for-linux issues, not pilot simulations. The criterion: if the skill draft was the one the maintainer actually posted (or used as the base for the posted comment) in twenty-five or more of those thirty, retire those phases and shrink the public bot comment to Phase 1 only.

--- a/docs/plans/2026-05-15-skill-driven-triage-design.md
+++ b/docs/plans/2026-05-15-skill-driven-triage-design.md
@@ -134,7 +134,7 @@ The `[Sim]` shadow issues during the eval are clearly marked and cross-linked to
 
 Three taxonomy and retrieval observations from the simulation that became concrete follow-ups:
 
-A `downloads` hat is worth adding. Two of the last ten issues (#2512 feature request for progress indicators, #2518 concurrent download stall) had no clean fit in the current taxonomy and defaulted to `other` or `enhancement-demand-gating`. The latter was a stretch in both cases. A `downloads` hat with keyword boost on `download`, `will-download`, `DownloadItem`, `shell.openExternal`, `setDisplayMediaRequestHandler` would route similar future cases properly. Defer until a third download-area issue accumulates.
+A `downloads` hat is worth adding. Two of the last ten issues (#2512 feature request for progress indicators, #2518 concurrent download stall) had no clean fit in the current taxonomy and defaulted to `other` or `enhancement-demand-gating`. The latter was a stretch in both cases. A `downloads` hat with keyword boost on `download`, `will-download`, `DownloadItem`, `shell.openExternal` would route similar future cases properly. Defer until a third download-area issue accumulates.
 
 A `tracking-validation` hat is worth adding. #2508 (the ozone-platform default validation tracking issue) is a cohort-roll-up shape, not a diagnostic shape. `configuration-cli` was the closest available match but its Phase 1 asks are wrong for a tracking issue. The new hat would have a `tracking-validation` posture that signals "do not run Phase 1 missing-info checks on this issue, summarise the cohort instead." Worth adding when a second tracking issue surfaces; one example is not yet enough to anchor a hat.
 


### PR DESCRIPTION
## Summary

Updates the skill-driven triage design doc to reflect the implementation round:

- Status header: proposed → implemented (Tasks 1-3); Task 4 pilot complete, retirement of Go-side phases deferred
- Task 1 (MCP `get_brief_preview` tool): DONE via #144
- Task 2 (`hats.md` seed in teams-for-linux): DONE via IsmaelMartinez/teams-for-linux#2548
- Task 3 (skill integration step): DONE locally; distribution decision recorded (skill stays in maintainer's Claude config, not committed to either repo)
- Task 4 (quality evaluation): pilot complete with `[Sim]` #97-#106 in shadow paired against `[Triage]` outputs; findings recorded; retirement of Phase 2/4a/synthesis deferred pending real-use evidence (≥25 of 30 real invocations)
- Follow-ups section: `downloads` hat, `tracking-validation` hat, spurious `upstream_candidates: [802]` constant bug
- Open questions: marked the empty-retrieval question answered, others still open

## Test plan

- [x] Plain markdown doc edit; renders correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)