### PR TITLE
fix(webhook): sync issues.labels on labeled/unlabeled events

### DIFF
--- a/internal/store/integration_test.go
+++ b/internal/store/integration_test.go
@@ -172,3 +172,52 @@ func TestIngestEndpointIntegration(t *testing.T) {
 		t.Errorf("CountEvents = %d, want 2", count)
 	}
 }
+
+func TestUpdateIssueLabelsIntegration(t *testing.T) {
+	s := testDB(t)
+	ctx := context.Background()
+	repo := "integration-test/labels"
+	number := 12345
+
+	t.Cleanup(func() {
+		_, _ = s.Pool().Exec(ctx, "DELETE FROM issues WHERE repo = $1 AND number = $2", repo, number)
+	})
+
+	embedding := make([]float32, store.EmbeddingDim)
+	embedding[0] = 0.5
+
+	if err := s.UpsertIssue(ctx, store.Issue{
+		Repo:      repo,
+		Number:    number,
+		Title:     "Test issue",
+		Summary:   "summary",
+		State:     "open",
+		Labels:    []string{"blocked", "authentication"},
+		Embedding: embedding,
+	}); err != nil {
+		t.Fatalf("seed UpsertIssue: %v", err)
+	}
+
+	if err := s.UpdateIssueLabels(ctx, repo, number, []string{"help wanted", "authentication", "ready"}); err != nil {
+		t.Fatalf("UpdateIssueLabels: %v", err)
+	}
+
+	var labels []string
+	if err := s.Pool().QueryRow(ctx, "SELECT labels FROM issues WHERE repo = $1 AND number = $2", repo, number).Scan(&labels); err != nil {
+		t.Fatalf("read back labels: %v", err)
+	}
+	want := []string{"help wanted", "authentication", "ready"}
+	if len(labels) != len(want) {
+		t.Fatalf("labels len = %d, want %d (got %v)", len(labels), len(want), labels)
+	}
+	for i, l := range want {
+		if labels[i] != l {
+			t.Errorf("labels[%d] = %q, want %q", i, labels[i], l)
+		}
+	}
+
+	// Updating a non-existent row should not error (label events can arrive before the row is embedded).
+	if err := s.UpdateIssueLabels(ctx, repo, 99999, []string{"any"}); err != nil {
+		t.Errorf("UpdateIssueLabels on non-existent row returned error: %v", err)
+	}
+}

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -56,6 +56,22 @@ func (s *Store) UpsertDocument(ctx context.Context, doc Document) error {
 	return err
 }
 
+// UpdateIssueLabels replaces the labels column for an issue without touching
+// the embedding or any other field. Returns nil if the row does not exist
+// (label events can arrive before the issue has been embedded; the next
+// opened/edited event will populate the row).
+func (s *Store) UpdateIssueLabels(ctx context.Context, repo string, number int, labels []string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE issues
+		SET labels = $1, updated_at = now()
+		WHERE repo = $2 AND number = $3
+	`, labels, repo, number)
+	if err != nil {
+		return fmt.Errorf("update issue labels: %w", err)
+	}
+	return nil
+}
+
 // UpsertIssue inserts or updates an issue and its embedding.
 // If issue.CreatedAt is set (non-zero), it is used as the issue creation timestamp;
 // otherwise the database default (now()) applies. On conflict, created_at is never overwritten.

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -332,8 +332,24 @@ func (h *Handler) processEvent(ctx context.Context, event gh.IssueEvent) {
 		h.handleStateChange(ctx, repo, issue)
 	case "edited":
 		h.handleEdited(ctx, installationID, repo, issue, event.Changes)
+	case "labeled", "unlabeled":
+		h.handleLabelChange(ctx, repo, issue)
 	default:
 		h.logger.Info("ignoring action", "action", event.Action, "issue", issue.Number)
+	}
+}
+
+// handleLabelChange syncs the issue's labels column when GitHub emits a
+// labeled or unlabeled event. The full current label set comes through on
+// every label event, so we replace rather than diff. No re-embedding: label
+// edits do not affect the title/summary the embedding is computed from.
+func (h *Handler) handleLabelChange(ctx context.Context, repo string, issue gh.IssueDetail) {
+	labels := make([]string, len(issue.Labels))
+	for i, l := range issue.Labels {
+		labels[i] = l.Name
+	}
+	if err := h.store.UpdateIssueLabels(ctx, repo, issue.Number, labels); err != nil {
+		h.logger.Error("updating issue labels", "repo", repo, "issue", issue.Number, "error", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes the systemic part of #147. The webhook handler only acted on `opened`, `closed`, `reopened`, `edited`; all other issue actions (including `labeled` and `unlabeled`) fell through to "ignoring action" in the default case. The result: when GitHub labels changed without any other field change, the bot's `issues.labels` column stayed stale.

This is the root cause of `/brief-preview` returning `[802]` for every query: the bot's row for `#802` was stored when it carried `blocked`, the label was later removed on GitHub, but the bot never saw the change. `FindSimilarBlockedIssues` filters by stored labels, so `#802` keeps coming back.

## Changes

- `store.UpdateIssueLabels(ctx, repo, number, labels)` — lightweight UPDATE-only method. Replaces the labels column without recomputing the embedding (title/summary do not change on label events, so re-embedding would just burn a Gemini call). No-op when the row does not exist (label events can arrive before the issue has been embedded; the next `opened`/`edited` will populate it).
- Webhook: `case "labeled", "unlabeled":` calls `handleLabelChange`, which extracts the post-change label set from the issue payload (every label event includes the full current label list) and calls `UpdateIssueLabels`.
- Integration test: upsert-then-label-update happy path, and the no-op-on-missing-row case.

## Backfill

Existing stale rows are not backfilled by this PR. After this merges and deploys:
- For `#802` specifically, a single label toggle on GitHub (add and remove any label) will trigger the new handler twice and refresh the row.
- For other stale rows we do not yet know about, a one-shot reconciliation tool would be the cleanest fix. Not in scope here; happy to follow up with one if the corpus turns out to have a noticeable number of stale rows.

## Test plan

- [x] `go test ./internal/webhook/... ./internal/store/...` — green (integration tests require `-tags integration` and a live DB, ran the unit subset).
- [x] `go build ./...` — clean.
- [x] `golangci-lint run ./internal/webhook/... ./internal/store/...` — 0 issues.
- [ ] After deploy: trigger a label change on a teams-for-linux issue, observe the row updates. Then verify `/brief-preview` for an arbitrary issue no longer returns `[802]` once `#802`'s row is refreshed.

Refs: #147
Plan: `docs/plans/2026-05-15-skill-driven-triage-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)