### PR TITLE
Fix: add distance threshold to blocked-issue retrieval

### DIFF
--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -223,6 +223,8 @@ func (s *Store) FindSimilarBlockedIssues(ctx context.Context, repo string, embed
 		return nil, fmt.Errorf("set ivfflat.probes: %w", err)
 	}
 
+	const blockedDistanceThreshold = 0.50
+
 	rows, err := tx.Query(ctx, `
 		SELECT id, repo, number, title, summary, state, labels, milestone,
 		       embedding, created_at, updated_at, closed_at,
@@ -231,9 +233,10 @@ func (s *Store) FindSimilarBlockedIssues(ctx context.Context, repo string, embed
 		WHERE repo = $2
 		  AND state = 'open'
 		  AND $3 = ANY(labels)
+		  AND embedding <=> $1 < $5
 		ORDER BY embedding <=> $1
 		LIMIT $4
-	`, pgvector.NewVector(embedding), repo, "blocked", limit)
+	`, pgvector.NewVector(embedding), repo, "blocked", limit, blockedDistanceThreshold)
 	if err != nil {
 		return nil, fmt.Errorf("find similar blocked issues: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Add cosine distance threshold (0.50) to `FindSimilarBlockedIssues` so semantically distant blocked issues are not returned as upstream candidates
- Fixes the issue where #802 appeared as upstream_candidate for every query regardless of topic

Fixes #147

## Test plan

- [x] `go test ./...` passes
- [ ] After deploy: verify `/brief-preview` no longer returns `[802]` for unrelated queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)