### PR TITLE
docs: ADR-009 — retire the service, re-home the useful slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> **This project is being retired.** It ran its course as a successful experiment and answered the question it set out to: where intelligence belongs in a maintainer's workflow. The one capability that proved useful in real use — semantic recall over the full issue history — is moving into [teams-for-linux](https://github.com/IsmaelMartinez/teams-for-linux) as a thin local index the issue-review skill calls directly, and GitHub's native [semantic issue search](https://github.blog/changelog/2026-05-20-semantic-issue-search-in-copilot-chat/) (shipped 2026-05-20) is the eventual replacement for even that. The reasoning is recorded in [ADR-009](docs/decisions/009-retire-the-service.md); the wind-down steps are in the [retirement plan](docs/plans/2026-06-05-retire-service-keep-capability.md). The service is still running for now; execution is not yet scheduled.
+
 # GitHub Issue Triage Bot
 
 Helps maintainers of [Teams for Linux](https://github.com/IsmaelMartinez/teams-for-linux) triage GitHub issues faster by checking bug reports for completeness and surfacing relevant project documentation. When a new issue is opened, the bot analyzes its content and provides useful context drawn from troubleshooting guides, upstream Electron release notes, architecture decisions, and past issues.

--- a/docs/decisions/008-service-vs-tools.md
+++ b/docs/decisions/008-service-vs-tools.md
@@ -1,6 +1,6 @@
 # ADR-008: Bespoke service vs. a composition of tools and a skill
 
-Status: Proposed (under discussion — no decision made yet)
+Status: Resolved by ADR-009 (2026-06-05) — decision is to retire the service and re-home the useful slice
 Date: 2026-05-29
 
 ## Context

--- a/docs/decisions/009-retire-the-service.md
+++ b/docs/decisions/009-retire-the-service.md
@@ -1,0 +1,41 @@
+# ADR-009: Retire the Repository Strategist service — sunsetting a successful experiment
+
+Status: Accepted (wind-down decided; execution per `docs/plans/2026-06-05-retire-service-keep-capability.md`, not yet scheduled)
+Date: 2026-06-05
+Resolves: ADR-008 (service vs. tools — previously "under discussion")
+
+## Context
+
+This repository began as an issue-triage bot and evolved through a long sequence of deliberate pivots — dark factory, lean bot, repository strategist, silent RAG mode, skill-driven triage. Every pivot did the same structural thing: it moved reasoning out of the Go service and into the agent layer, until the service's remaining job was retrieval and weekly synthesis. ADR-008 framed the open question — whether a bespoke service was still justified, or whether a composition of off-the-shelf tools plus the existing Claude skill could do the job — and set a measurement gate rather than deciding on taste.
+
+That measurement has now run. Once the skill's retrieval wiring was repaired, the `teams-for-linux-issue-review` skill was used on roughly a dozen real issues over the following week, and a transcript-mining pass turned "is it useful?" into a number: about a third of the bot's similar-issue suggestions were cited in the resulting drafts, with a strongly bimodal shape — genuinely additive on recurring auth and login themes, and adding nothing the draft used on novel issues. Every other capability showed near-zero consumption: the weekly synthesis findings were glanced at on the dashboard with no evidence they were ever acted on, the `/report/trends` endpoint built for a programmatic consumer had no reads, the upstream-candidates field returned the same content regardless of input, and the learnings field returned generic label entries unrelated to the diagnosis. Against that thin, narrow value sat a standing Cloud Run service, a Neon Postgres database, CI, and Terraform — and a recurring maintenance tax that the final weeks of the project spent paying down (an embedding leak, a dead metric, documentation drift, a misrouted MCP registration), all on a service handling a handful of calls a day.
+
+Then the landscape moved. On 2026-05-20 GitHub shipped native semantic issue search in Copilot Chat (generally available on all Copilot plans, backed by a real semantic issues index) alongside semantic code search in the Copilot coding agent. The one capability ADR-008 had called hard to buy — longitudinal semantic search over a single repo's issue history — became a commodity, covering both halves of our useful slice with no operational surface on our side. The only present limitation is that the semantic issues index is reachable from the Copilot Chat web UI rather than from a public API or the GitHub MCP server, so it cannot yet be called programmatically from the skill.
+
+## Decision
+
+Retire the bespoke service. Dissolve the Cloud Run deployment, the Neon database, and the surrounding CI and Terraform, and re-home the single capability that earned its keep — semantic recall over the issue history — into `teams-for-linux` as a thin local embedding index the skill calls directly, exactly as set out in the 2026-06-05 implementation plan. That local index is a deliberate bridge: GitHub's native semantic search is the strategic destination, and the bridge is kept intentionally thin so that when GitHub exposes the index through an API or MCP tool, the skill swaps to it and the local index is deleted. Codenav is not rebuilt; the skill reads the local checkout and Copilot's semantic code search covers the rest. The off-the-shelf full-triage product (Dosu) was considered and rejected as the wrong shape — it auto-labels and replies, which contradicts the silent-mode posture, and is enterprise contact-priced. With the service gone, the long-deferred rename (roadmap Stream 7) resolves itself: the repository is archived or reduced to the home of the indexing script.
+
+This is recorded deliberately as the retirement of a successful experiment, not the failure of one. The experiment was productive precisely because it ran far enough to produce evidence, and the right time to close an experiment is when it has answered its question.
+
+## What the experiment proved — learnings harvested
+
+The value of this project is the body of learnings it produced about where intelligence should live in a maintainer's workflow, and those are worth recording even as the code is retired.
+
+On RAG: semantic vector recall genuinely surfaced old, differently-worded issues that keyword search misses — the one durable win — but RAG over the small documentation corpus, a few dozen files that fit comfortably in an agent's context window, was over-engineering that an agent simply reading `docs/` does better. On shadow repos: mirroring issues into a private repository to give an agent a workspace was heavy infrastructure whose real value turned out to be the analysis it produced rather than the mirror itself, which is why it was retired in ADR-014. On bot promotions and reply drafting: the maintainer-style reply drafter matured best as a Claude Code skill in the agent layer, not as logic embedded in the service. On dashboards: a live charts dashboard gave glanceable status but was viewed only occasionally and never drove a decision, a reminder that a dashboard nobody acts on is vanity. On observability and trend reporting: the structured `/report/trends` endpoint built for a programmatic consumer went unread because that consumer was never wired up, teaching that the producer should not be built before the consumer. On silent mode: replacing automatic public comments with on-demand retrieval matched what the maintainer actually wanted — judgement in the loop rather than auto-posted bot noise. And on measurement discipline: instrumenting real use before deciding is what turned a vague "is this useful?" into a concrete usage rate, and that number is what finally grounded this retirement rather than intuition.
+
+The throughline across all of them is the same conclusion every pivot pointed at: reasoning belongs in the agent and the skill, durable memory belongs in a tiny local index, and the heavy always-on service in between was scaffolding the workflow outgrew.
+
+## Consequences
+
+The maintainer keeps the capability that worked, in a form with no servers, no database, and no monthly cost, callable from the skill today and swappable for GitHub's native search tomorrow. The recurring maintenance burden disappears, along with the budget for Cloud Run and Neon. The synthesis engine, dashboard, health monitor, event journal, and the already-retired agent and mirror subsystems are wound down; their findings were not consumed, so nothing downstream breaks. Decommissioning starts by uninstalling the GitHub App and removing its webhook from teams-for-linux so issue events stop reaching a dead endpoint, and includes removing the now-defunct `triage-bot` MCP registration that points at the retired Cloud Run URL. The Git history is preserved as the record of the experiment. The risks and rollback path are covered in the implementation plan: the service can be left scaled-to-zero rather than destroyed until the local path is proven on a few live issues, and reverting is a single skill edit. Execution is not yet scheduled; this ADR records the decision and the reasoning so the wind-down proceeds deliberately.
+
+## References
+
+- ADR-008 (service vs. tools, now resolved): `docs/decisions/008-service-vs-tools.md`
+- Implementation plan: `docs/plans/2026-06-05-retire-service-keep-capability.md`
+- Silent mode: `docs/decisions/002-silent-mode.md`
+- Shadow-repo pattern and its retirement: `docs/decisions/003-shadow-repo-pattern.md`, `docs/adr/014-retire-shadow-repos.md`
+- Weekly synthesis engine: `docs/decisions/006-weekly-synthesis-engine.md`
+- simili-bot trial (a prior buy-vs-build call): `docs/decisions/007-simili-bot-trial.md`
+- GitHub native semantic issue search (2026-05-20): github.blog/changelog/2026-05-20-semantic-issue-search-in-copilot-chat

--- a/docs/plans/2026-06-05-retire-service-keep-capability.md
+++ b/docs/plans/2026-06-05-retire-service-keep-capability.md
@@ -1,0 +1,51 @@
+# Plan: retire the bespoke service, keep the useful slice (move into teams-for-linux)
+
+Status: Proposed (planning only — no code or infra changes made yet)
+Date: 2026-06-05
+Relates to: `docs/decisions/008-service-vs-tools.md` (ADR-008), roadmap Stream 7 (rename), the real-use findings recorded in agent memory.
+
+## Decision in one paragraph
+
+The measured real use of `/brief-preview` says the bespoke service has one capability worth keeping — semantic recall over the full issue history (and, secondarily, codenav) — and that everything else (synthesis findings, the upstream-candidates and learnings fields, the dashboard, the health monitor, the retired agent and mirror code) is unconsumed. Across ~12 distinct real issues the usage proxy held steady at roughly a third of the bot's similar-issue suggestions being cited in drafts, strongly bimodal: materially additive on recurring auth/login-themed issues, zero on novel ones. The plan is therefore to dissolve the standing Cloud Run + Neon service and re-home its one useful capability inside `teams-for-linux` as a thin, no-ops local tool the `teams-for-linux-issue-review` skill calls directly, built deliberately small so it can be swapped for GitHub's new native semantic issue search once that exposes an API.
+
+## What changed in the landscape (the headline)
+
+The thing ADR-008 called the irreducible, hard-to-buy core — longitudinal semantic search over a single repo's issue history — stopped being hard to buy. On 2026-05-20 GitHub shipped semantic issue search in Copilot Chat, generally available on all Copilot plans and powered by a dedicated semantic issues index, and earlier shipped semantic code search inside the Copilot coding agent. Between them they cover both halves of our useful slice natively, with zero operational surface on our side. The one limitation, confirmed against the changelog and the GitHub MCP server's toolset docs, is that the semantic issues index is reachable only from Copilot Chat on the web today; there is no documented REST, GraphQL, or MCP surface, and the GitHub MCP server's `issues` toolset still uses the keyword search API. So a Claude Code skill cannot call GitHub's semantic index programmatically yet — but the direction of travel is unmistakable, and GitHub historically exposes UI features through APIs over time. This reframes the whole question: we are no longer deciding whether to maintain a unique capability forever, only how to bridge the gap until the commodity version is callable from where we need it.
+
+## The off-the-shelf options, weighed
+
+GitHub native semantic issue and code search is the strategic destination. It is free on existing Copilot plans, maintained by GitHub, and is exactly the capability. Its only gap is programmatic access from the skill, which is a question of timing, not feasibility. The maintainer can already use it manually today by asking Copilot Chat for issues similar to the one under triage, as a cross-check.
+
+Dosu is the closest off-the-shelf full-triage product (auto-labelling, deduplication, and replies driven by a semantic layer). It is the wrong shape for this project: it posts automatically, which conflicts directly with the silent-mode posture (ADR-014) and the maintainer's explicit preference to keep their judgement in the loop; its pricing is enterprise contact-sales; and it would replace the skill rather than feed it. Notably, even Dosu is moving toward less hosted machinery and more in-repo control (its `better-stale-bot` direction), which validates the dissolve-the-service instinct rather than contradicting it.
+
+A local committed embedding index is the pragmatic bridge that works inside the skill today. The issue corpus is small (~1,400 embedded issues out of ~2,600 issue numbers), so semantic search over it is a few megabytes and a brute-force cosine — no database, no service. The maintainer already runs local embedding models through the `delegate-local` skill (`embed.sh` / `semantic-search.sh`), so the whole capability can run on-device with no API key and no recurring cost.
+
+Keeping the bespoke service is rejected by the data and the maintenance ledger: this very stretch of work has been spent fixing an embedding leak, a dead metric, doc drift, and a misrouted MCP registration on a service handling a handful of calls a day and then none for a day.
+
+## Recommended approach: two tracks
+
+Track one, now: replace the service's role with a local embedding index committed to `teams-for-linux`, consumed by the skill's step 1c, and retire Cloud Run + Neon. Build it deliberately thin — a single search entry point with a stable contract — so that track two is a cheap swap rather than a rewrite.
+
+Track two, strategic: treat GitHub native semantic search as the eventual backend. The moment GitHub exposes the semantic issues index via API or the official MCP server, the skill's step 1c switches from the local script to that call and the committed index is deleted. Until then, the maintainer uses Copilot Chat semantic search manually as a parallel sanity check. Codenav is not rebuilt at all: the skill already has the repo checked out locally and can grep and read it, and Copilot semantic code search covers the rest.
+
+## Implementation steps (track one)
+
+1. Re-home, do not migrate, the data. The issue corpus is public and re-fetchable via `gh`, so regenerate embeddings from scratch with the local model rather than exporting the Neon pgvector table. This drops the Gemini dependency entirely and avoids a fragile migration.
+2. Add a small `issue-recall/` tool to `teams-for-linux` (exact location TBD with the maintainer — likely under an existing scripts/tools dir). It contains: a committed, compressed embeddings file (`{number, title, state, vector}` for all issues, float16 to keep it a few MB); a `search` entry point that embeds the query with the same local model, computes cosine similarity, and prints the top-k similar issues in a stable format; and a `reindex` entry point that fetches issues via `gh`, embeds new or changed ones, and rewrites the committed file.
+3. Pin one embedding model for both index and query (cosine is only valid if both sides use the same model). Use the `delegate-local` embedding tier so it stays on-device; document the model name so a future model change triggers a full reindex.
+4. Refresh cadence: a maintainer-run `reindex` (matching the keep-it-manual preference) rather than an always-on automation, optionally backed by a scheduled GitHub Action later if staleness becomes annoying. Re-embedding only the delta keeps it cheap.
+5. Rewire the skill. Change step 1c in `teams-for-linux-issue-review/SKILL.md` from the `curl .../brief-preview` call to invoking the local `search` entry point, keeping the same downstream contract (a list of similar issues the draft can cite). This is the only change to the skill's behaviour; the rest of the hat logic is unaffected.
+6. Decommission the service once the local path is proven on a few live issues, in this order: first uninstall the GitHub App and remove its webhook from `teams-for-linux` (so issue events stop POSTing to a soon-dead endpoint), then `terraform destroy` the Cloud Run service, Artifact Registry image, budget, and secrets; delete the Neon project; remove the GitHub Actions deploy/seed/synthesis/event-ingest workflows; and remove the now-defunct `triage-bot` MCP registration from the local Claude config (it points at the retired Cloud Run URL). Keep the Git history.
+7. Resolve the identity question (roadmap Stream 7) as a consequence: with the service gone, `github-issue-triage-bot` is either archived read-only or reduced to the home of the indexing script; the rename becomes moot or trivial.
+
+## Migration, rollback, and risks
+
+Rollback during the bridge is simple because the service can be left scaled-to-zero (not destroyed) until the local path has handled a handful of live issues; if the local index underperforms, step 1c reverts to the `curl` call by reverting one skill edit. The main risk is embedding-quality parity: the local model's neighbours may differ from Gemini's, so the first few reindexed results should be spot-checked against the recorded dataset (the same auth/login issues that scored well before should still surface). A second, smaller risk is index staleness between manual reindexes; this is acceptable because the highest-value matches are old recurring issues that do not change, and the freshest issues are exactly the ones a plain `gh search` already catches. The codenav decision carries effectively no risk since nothing is built.
+
+## Open decisions for the maintainer
+
+Whether to run the local index on the `delegate-local` on-device model (zero cost, zero external dependency, reindex must run on the maintainer's machine) or on a hosted embedder like Gemini called only at reindex and query time (no standing service, but a re-introduced API dependency). The recommendation is the on-device model, for full alignment with the no-ops goal. Also open: whether to destroy the service immediately after the bridge is proven or leave it scaled-to-zero for a grace period; and where exactly the tool should live inside `teams-for-linux`.
+
+## What this plan is not
+
+It does not commit any code or infrastructure change. It records the recommended path and the concrete steps so the dissolve-and-rehome can be executed deliberately, and so the eventual switch to GitHub's native semantic search is a planned swap rather than a surprise.


### PR DESCRIPTION
Records the decision to retire the bespoke Cloud Run + Neon triage-bot service and resolves the open question in ADR-008.

## What's here
- **ADR-009** (`docs/decisions/009-retire-the-service.md`, Accepted) — frames this as sunsetting a *successful* experiment, with the evidence (real-use measurement: ~12 issues, ~34% suggestion-usage, bimodal) and a learnings-harvested section (RAG, shadow repos, bot promotions, dashboards, observability, silent mode, measurement discipline).
- **Retirement plan** (`docs/plans/2026-06-05-retire-service-keep-capability.md`) — the two-track path: now, re-home semantic issue-history recall into teams-for-linux as a thin local embedding index called from the skill's step 1c; later, swap to GitHub's native semantic issue search (shipped 2026-05-20) once it's API/MCP-callable. Includes decommission ordering (uninstall the GitHub App + webhook first, then destroy infra, then remove the dead MCP registration).
- **ADR-008** status updated to "Resolved by ADR-009".
- **README** sunset banner explaining why and linking next steps.

## Notes
- Docs only — no code or infrastructure changed. The service is still running; execution is not yet scheduled.
- Decision recorded for deliberate wind-down, not immediate teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)