### PR TITLE
fix(ci): pin govulncheck and make the vulnerability scan non-blocking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,10 +29,63 @@ jobs:
         run: |
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
           golangci-lint run ./...
+
+  # Advisory-driven, so deliberately NOT a required check: a newly published Go
+  # advisory must never silently block every open PR (see #169). The signal is
+  # still surfaced - this job goes red and, on main, opens/refreshes a tracking
+  # issue.
+  vulncheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        with:
+          go-version-file: go.mod
+
       - name: Vulnerability check
+        id: scan
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./...
+          go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
+          if govulncheck ./... > govulncheck.txt 2>&1; then
+            echo "clean=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "clean=false" >> "$GITHUB_OUTPUT"
+          fi
+          cat govulncheck.txt
+
+      - name: Open or refresh tracking issue
+        if: steps.scan.outputs.clean == 'false' && github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: "govulncheck: vulnerabilities detected on main"
+        run: |
+          {
+            echo "\`govulncheck\` reported vulnerabilities on \`main\` (\`${GITHUB_SHA}\`)."
+            echo
+            echo '```'
+            cat govulncheck.txt
+            echo '```'
+            echo
+            echo "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } > body.md
+
+          existing=$(gh issue list --state open --limit 100 --json number,title \
+            | jq -r --arg t "$TITLE" 'map(select(.title == $t)) | .[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file body.md
+          else
+            gh issue create --title "$TITLE" --body-file body.md
+          fi
+
+      - name: Report scan result
+        if: steps.scan.outputs.clean == 'false'
+        run: |
+          echo "::error::govulncheck reported vulnerabilities - see the job log and the tracking issue"
+          exit 1
 
   deploy:
     needs: test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,13 +32,17 @@ jobs:
 
   # Advisory-driven, so deliberately NOT a required check: a newly published Go
   # advisory must never silently block every open PR (see #169). The signal is
-  # still surfaced - this job goes red and, on main, opens/refreshes a tracking
-  # issue.
+  # still surfaced - this job goes red, and on main the vulncheck-issue job
+  # opens/refreshes a tracking issue.
+  # Read-only token: this job compiles PR-supplied code, so it must not be able
+  # to write anything.
   vulncheck:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
+    outputs:
+      clean: ${{ steps.scan.outputs.clean }}
+      report: ${{ steps.scan.outputs.report }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
@@ -56,36 +60,59 @@ jobs:
           fi
           cat govulncheck.txt
 
-      - name: Open or refresh tracking issue
-        if: steps.scan.outputs.clean == 'false' && github.event_name == 'push'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TITLE: "govulncheck: vulnerabilities detected on main"
-        run: |
+          # Bounded excerpt for the tracking issue body, which has a hard size
+          # limit. The run log above always holds the full report.
           {
-            echo "\`govulncheck\` reported vulnerabilities on \`main\` (\`${GITHUB_SHA}\`)."
+            echo 'report<<GOVULN_REPORT_EOF'
+            head -c 8000 govulncheck.txt
             echo
-            echo '```'
-            cat govulncheck.txt
-            echo '```'
-            echo
-            echo "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          } > body.md
-
-          existing=$(gh issue list --state open --limit 100 --json number,title \
-            | jq -r --arg t "$TITLE" 'map(select(.title == $t)) | .[0].number // empty')
-
-          if [ -n "$existing" ]; then
-            gh issue edit "$existing" --body-file body.md
-          else
-            gh issue create --title "$TITLE" --body-file body.md
-          fi
+            if [ "$(wc -c < govulncheck.txt)" -gt 8000 ]; then
+              echo '[truncated - see the workflow run log for the full report]'
+            fi
+            echo 'GOVULN_REPORT_EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - name: Report scan result
         if: steps.scan.outputs.clean == 'false'
         run: |
           echo "::error::govulncheck reported vulnerabilities - see the job log and the tracking issue"
           exit 1
+
+  # Split out so that only the push-to-main path ever holds `issues: write`.
+  # It builds nothing and checks nothing out - it only files the report.
+  vulncheck-issue:
+    needs: vulncheck
+    if: always() && github.event_name == 'push' && needs.vulncheck.outputs.clean == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or refresh tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TITLE: "govulncheck: vulnerabilities detected on main"
+          REPORT: ${{ needs.vulncheck.outputs.report }}
+        run: |
+          {
+            echo "\`govulncheck\` reported vulnerabilities on \`main\` (\`${GITHUB_SHA}\`)."
+            echo
+            echo '```'
+            printf '%s\n' "$REPORT"
+            echo '```'
+            echo
+            echo "Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          } > body.md
+
+          existing=$(gh issue list --state open --limit 100 --json number,title \
+            --jq 'map(select(.title == env.TITLE)) | .[0].number // empty')
+
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file body.md
+          else
+            gh issue create --title "$TITLE" --body-file body.md
+          fi
 
   deploy:
     needs: test

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/IsmaelMartinez/github-issue-triage-bot
 
 go 1.26
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.19.0
@@ -19,6 +19,6 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
-	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/text v0.36.0 // indirect
+	golang.org/x/sync v0.21.0 // indirect
+	golang.org/x/text v0.39.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -33,10 +33,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
-golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
-golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
+golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
+golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
+golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Problem

Every open PR in this repo is `BLOCKED`. `test` is the only required status check, and its `Vulnerability check` step ran:

```
go install golang.org/x/vuln/cmd/govulncheck@latest
govulncheck ./...
```

An unpinned `@latest` scanner reading a live advisory feed, wired as a blocking gate. As soon as a new advisory publishes, every PR goes red with no code change and nothing to fix in the PR itself.

That is exactly what happened. Since 2026-07-13, `test` has failed on:

```
Vulnerability #1: GO-2026-5856
    Invoking Encrypted Client Hello privacy leak in crypto/tls
    Found in: crypto/tls@go1.26.4
    Fixed in: crypto/tls@go1.26.5
Process completed with exit code 3
```

Collateral: PRs #169 (12 days), #170 and #171 have all been blocked by this, none of them related to the failure. I re-ran the failed job on #169 against current `main` and it still fails identically, so this is live, not a stale artifact. This is also the second occurrence of the same class — #165 ("bump Go to 1.26.4 to clear stdlib CVEs") was the same treadmill in June.

## Fix

Pin the scanner and stop it gating merges, without losing the signal:

- `govulncheck` pinned to `v1.6.0` so the tool version is reproducible.
- The scan moves into its own `vulncheck` job. It is not a required check, so an advisory can no longer block merges. It still fails visibly, and on pushes to `main` it opens (or refreshes, deduped by title) a tracking issue containing the scan output. The vulnerability signal is preserved and made actionable rather than dropped.
- `test` keeps its name and remains the required check; `deploy` still `needs: test`.

Also cleared the two advisories currently outstanding, both patch/minor within the same major:

- toolchain `go1.26.4` → `go1.26.5`, clearing GO-2026-5856.
- `golang.org/x/text` `v0.36.0` → `v0.39.0`, clearing GO-2026-5970 (infinite loop on invalid input), which surfaced once the toolchain bump revealed it.

## Verification

Locally on go1.26.5:

- `go test ./...` — all packages pass.
- `govulncheck ./...` — `No vulnerabilities found.`

## Unblocks #169

Once this merges, `test` no longer contains the advisory-driven step, so #169, #170 and #171 stop being `BLOCKED` on a defect none of them introduced. #169 is the repo-butler's own `standards-gap/release-cadence` remediation; its `release.yml` is not implicated in the failure at all. Those PRs will need a rebase onto this commit to pick up the new `test` definition (branch protection has `strict: true`).

Not touched, out of scope, but worth knowing — two further pre-existing defects in scheduled workflows, neither part of `test` nor blocking any PR:

- `webhook-catchup.yml` and `dashboard.yml` reference `secrets.BOT_GITHUB_TOKEN`, which does not exist in this repo's secrets.
- `synthesis.yml` has failed 8 consecutive weekly runs (2026-06-01 → 2026-07-20) POSTing to the Cloud Run endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)